### PR TITLE
Stricter CORS headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/arduino/arduino-builder/src/github.com/itsjamie/gin-cors"
 	"github.com/carlescere/scheduler"
 	"github.com/gin-gonic/gin"
-	"github.com/itsjamie/gin-cors"
 	"github.com/kardianos/osext"
 	"github.com/vharitonsky/iniflags"
 	//"github.com/sanbornm/go-selfupdate/selfupdate" #included in update.go to change heavily
@@ -236,6 +236,10 @@ func main() {
 			if err != nil {
 				panic(err)
 			}
+			// All the ports p in the range  8990 <= p <= portPlain
+			// has already been scanned and results not free.
+			// Thus we can restrict the search range for portSSL
+			// to [portPlain+1, 9001).
 			portSSL, err := getBindPort(portPlain+1, 9001)
 			if err != nil {
 				panic(err)

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/arduino/arduino-builder/src/github.com/itsjamie/gin-cors"
+	"github.com/itsjamie/gin-cors"
 	"github.com/carlescere/scheduler"
 	"github.com/gin-gonic/gin"
 	"github.com/kardianos/osext"

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"errors"
 	"flag"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -73,6 +75,21 @@ func launchSelfLater() {
 	log.Println("Going to launch myself 2 seconds later.")
 	time.Sleep(2 * 1000 * time.Millisecond)
 	log.Println("Done waiting 2 secs. Now launching...")
+}
+
+// getBindPort returns the first bindable port in the given range
+func getBindPort(minPort, maxPort int) (int, error) {
+
+	for i := minPort; i < maxPort; i++ {
+		ln, _ := net.Listen("tcp", ":"+strconv.Itoa(i))
+		if ln != nil {
+			ln.Close()
+			return i, nil
+		}
+	}
+
+	return -1, errors.New("Unable to bind any port in the range [" + strconv.Itoa(minPort) + "," + strconv.Itoa(maxPort) + ")")
+
 }
 
 func main() {
@@ -215,11 +232,18 @@ func main() {
 
 			socketHandler := wsHandler().ServeHTTP
 
-			extraOriginStr := "https://create.arduino.cc, http://create.arduino.cc, https://create-dev.arduino.cc, http://create-dev.arduino.cc, http://create-staging.arduino.cc, https://create-staging.arduino.cc"
-
-			for i := 8990; i < 9001; i++ {
-				extraOriginStr = extraOriginStr + ", http://localhost:" + strconv.Itoa(i) + ", https://localhost:" + strconv.Itoa(i)
+			portPlain, err := getBindPort(8990, 9001)
+			if err != nil {
+				panic(err)
 			}
+			portSSL, err := getBindPort(portPlain+1, 9001)
+			if err != nil {
+				panic(err)
+			}
+
+			extraOriginStr := "https://create.arduino.cc, http://create.arduino.cc, https://create-dev.arduino.cc, http://create-dev.arduino.cc, http://create-staging.arduino.cc, https://create-staging.arduino.cc"
+			extraOriginStr += ", http://localhost:" + strconv.Itoa(portPlain) + ", https://localhost:" + strconv.Itoa(portPlain)
+			extraOriginStr += ", http://localhost:" + strconv.Itoa(portSSL) + ", https://localhost:" + strconv.Itoa(portSSL)
 
 			r.Use(cors.Middleware(cors.Config{
 				Origins:         *origins + ", " + extraOriginStr,
@@ -247,38 +271,23 @@ func main() {
 					return
 				}
 
-				start := 8990
-				end := 9000
-				i := start
-				for i < end {
-					i = i + 1
-					portSSL = ":" + strconv.Itoa(i)
-					if err := r.RunTLS(portSSL, filepath.Join(dest, "cert.pem"), filepath.Join(dest, "key.pem")); err != nil {
-						log.Printf("Error trying to bind to port: %v, so exiting...", err)
-						continue
-					} else {
-						ip := "0.0.0.0"
-						log.Print("Starting server and websocket (SSL) on " + ip + "" + port)
-						break
-					}
+				portStr := ":" + strconv.Itoa(portSSL)
+				if err := r.RunTLS(portStr, filepath.Join(dest, "cert.pem"), filepath.Join(dest, "key.pem")); err != nil {
+					log.Printf("Error trying to bind to port: %v, so exiting...", err)
+				} else {
+					ip := "0.0.0.0"
+					log.Print("Starting server and websocket (SSL) on " + ip + "" + port)
 				}
 			}()
 
 			go func() {
-				start := 8990
-				end := 9000
-				i := start
-				for i < end {
-					i = i + 1
-					port = ":" + strconv.Itoa(i)
-					if err := r.Run(port); err != nil {
-						log.Printf("Error trying to bind to port: %v, so exiting...", err)
-						continue
-					} else {
-						ip := "0.0.0.0"
-						log.Print("Starting server and websocket on " + ip + "" + port)
-						break
-					}
+
+				portStr := ":" + strconv.Itoa(portPlain)
+				if err := r.Run(portStr); err != nil {
+					log.Printf("Error trying to bind to port: %v, so exiting...", err)
+				} else {
+					ip := "0.0.0.0"
+					log.Print("Starting server and websocket on " + ip + "" + port)
 				}
 			}()
 


### PR DESCRIPTION
Trying to fix issue #56 during the Torino HackNight contest.

The idea is basically to select a pair of free port from port-range using the `net.Listen` function.
The two ports are later used by gin to listen for incoming HTTP or HTTPS connections.