### PR TITLE
Add CORS origins for Scratch and ScratchX

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -7,4 +7,4 @@ v = true  # show debug logging
 appName = CreateBridge
 updateUrl = http://downloads.arduino.cc/
 #updateUrl = http://localhost/
-origins = http://webide.arduino.cc:8080
+origins = http://webide.arduino.cc:8080, https://scratch.mit.edu, http://scratchx.org


### PR DESCRIPTION
Scratch hardware extensions are written in JavaScript and loaded in
[Scratch](https://scratch.mit.edu) or the experimental extension site, [ScratchX](http://scratchx.org).

This change will allow the [Scratch Arduino extension](http://khanning.github.io/scratch-arduino-extension/) to use the
Create agent to communicate directly with Arduino boards.