### PR TITLE
Remove Scratch and ScratchX CORS entries

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -7,4 +7,4 @@ v = true  # show debug logging
 appName = CreateBridge
 updateUrl = http://downloads.arduino.cc/
 #updateUrl = http://localhost/
-origins = http://webide.arduino.cc:8080, https://scratch.mit.edu, http://scratchx.org
+origins = http://webide.arduino.cc:8080


### PR DESCRIPTION
Removing the entries for Scratch and ScratchX while we look
into what changes are necessary to make this useful for the
Scratch Arduino extension.