### PR TITLE
Only check command signature in non-network mode

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -98,6 +98,7 @@ func uploadHandler(c *gin.Context) {
 	path, err := saveFileonTempDir(data.Filename, buffer)
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
+		return
 	}
 
 	if data.Rewrite != "" {

--- a/conn.go
+++ b/conn.go
@@ -74,23 +74,23 @@ func uploadHandler(c *gin.Context) {
 		return
 	}
 
-	if data.Signature == "" {
-		c.String(http.StatusBadRequest, "signature is required")
-		return
-	}
+	if data.Extra.Network == false {
+		if data.Signature == "" {
+			c.String(http.StatusBadRequest, "signature is required")
+			return
+		}
 
-	if data.Extra.Network {
+		if data.Commandline == "" {
+			c.String(http.StatusBadRequest, "commandline is required for local board")
+			return
+		}
+
 		err := verifyCommandLine(data.Commandline, data.Signature)
 
 		if err != nil {
 			c.String(http.StatusBadRequest, "signature is invalid")
 			return
 		}
-	}
-
-	if data.Extra.Network == false && data.Commandline == "" {
-		c.String(http.StatusBadRequest, "commandline is required for local board")
-		return
 	}
 
 	buffer := bytes.NewBuffer(data.Hex)


### PR DESCRIPTION
Previously the command signature was only being verified in network mode, when it needs to be checked in non-network mode instead.