### PR TITLE
Allow attaching additional files in the POST

### DIFF
--- a/tools/download.go
+++ b/tools/download.go
@@ -53,7 +53,7 @@ type index struct {
 var systems = map[string]string{
 	"linuxamd64":  "x86_64-linux-gnu",
 	"linux386":    "i686-linux-gnu",
-	"darwinamd64": "i386-apple-darwin11",
+	"darwinamd64": "apple-darwin",
 	"windows386":  "i686-mingw32",
 }
 
@@ -71,7 +71,6 @@ func checkGPGSig(fileName string, sigFileName string) error {
 	if err != nil {
 		return err
 	}
-
 	defer sigFile.Close()
 
 	// Get a Reader for the signature file
@@ -79,7 +78,6 @@ func checkGPGSig(fileName string, sigFileName string) error {
 	if err != nil {
 		return err
 	}
-
 	defer file.Close()
 
 	publicKeyBin, err := hex.DecodeString(publicKeyHex)
@@ -179,7 +177,7 @@ func (t *Tools) Download(name, version, behaviour string) error {
 
 	// Find the url based on system
 	var correctSystem system
-	max_similarity := 0.8
+	max_similarity := 0.7
 
 	for _, s := range correctTool.Systems {
 		similarity := smetrics.Jaro(s.Host, systems[runtime.GOOS+runtime.GOARCH])
@@ -252,7 +250,10 @@ func (t *Tools) Download(name, version, behaviour string) error {
 		return err
 	}
 
-	t.installDrivers(location)
+	err = t.installDrivers(location)
+	if err != nil {
+		return err
+	}
 
 	// Ensure that the files are executable
 	t.Logger.Println("Ensure that the files are executable")
@@ -411,10 +412,9 @@ func extractTarGz(body []byte, location string) (string, error) {
 		}
 
 		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
-		if err != nil {
-			//return location, err
+		if err == nil {
+			defer file.Close()
 		}
-		defer file.Close()
 		_, err = io.Copy(file, tarReader)
 		if err != nil {
 			//return location, err
@@ -423,15 +423,26 @@ func extractTarGz(body []byte, location string) (string, error) {
 	return location, nil
 }
 
-func (t *Tools) installDrivers(location string) {
+func (t *Tools) installDrivers(location string) error {
 	if runtime.GOOS == "windows" {
 		if _, err := os.Stat(filepath.Join(location, "post_install.bat")); err == nil {
 			t.Logger.Println("Installing drivers")
-			oscmd := exec.Command(filepath.Join(location, "post_install.bat"))
-			TellCommandNotToSpawnShell(oscmd)
-			oscmd.Run()
+			ok := MessageBox("Installing drivers", "We are about to install some drivers needed to use Arduino/Genuino boards\nDo you want to continue?")
+			t.Logger.Println(ok)
+			if ok == 6 {
+				os.Chdir(location)
+				oscmd := exec.Command("post_install.bat")
+				TellCommandNotToSpawnShell(oscmd)
+				t.Logger.Println(oscmd)
+				err = oscmd.Run()
+				t.Logger.Println(err)
+				return err
+			} else {
+				return errors.New("Could not install drivers")
+			}
 		}
 	}
+	return nil
 }
 
 func extractBz2(body []byte, location string) (string, error) {
@@ -479,10 +490,9 @@ func extractBz2(body []byte, location string) (string, error) {
 		}
 
 		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
-		if err != nil {
-			//return location, err
+		if err == nil {
+			defer file.Close()
 		}
-		defer file.Close()
 		_, err = io.Copy(file, tarReader)
 		if err != nil {
 			//return location, err

--- a/tools/hidefile_darwin.go
+++ b/tools/hidefile_darwin.go
@@ -10,3 +10,7 @@ func hideFile(path string) {
 
 func TellCommandNotToSpawnShell(_ *exec.Cmd) {
 }
+
+func MessageBox(title, text string) int {
+	return 0
+}

--- a/tools/hidefile_linux.go
+++ b/tools/hidefile_linux.go
@@ -10,3 +10,7 @@ func hideFile(path string) {
 
 func TellCommandNotToSpawnShell(_ *exec.Cmd) {
 }
+
+func MessageBox(title, text string) int {
+	return 0
+}

--- a/tools/hidefile_windows.go
+++ b/tools/hidefile_windows.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"os/exec"
 	"syscall"
+	"unsafe"
 )
 
 func hideFile(path string) {
@@ -14,4 +15,16 @@ func hideFile(path string) {
 
 func TellCommandNotToSpawnShell(oscmd *exec.Cmd) {
 	oscmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+}
+
+func MessageBox(title, text string) int {
+	var mod = syscall.NewLazyDLL("user32.dll")
+	var proc = mod.NewProc("MessageBoxW")
+	var MB_YESNO = 0x00000004
+
+	ret, _, _ := proc.Call(0,
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(text))),
+		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(title))),
+		uintptr(MB_YESNO))
+	return int(ret)
 }


### PR DESCRIPTION
To allow upload using tools which rely on {runtime.*} variables

Actions server side:
- Compile a "blacklist" (eg : {runtime.platform.path}/variants/{build.variant} )
- Replace these entries with {build.path} when found in commandline
- Map the blacklisted entry to a set of extra files to be uploaded
- Profit