### PR TITLE
Handle redirects for Yun shield sketch upload

### DIFF
--- a/programmer.go
+++ b/programmer.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -195,7 +196,16 @@ func spProgramNetwork(portname string, boardname string, filePath string, authda
 
 	// Submit the request
 	client := &http.Client{}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return errors.New("redirect")
+	}
 	res, err := client.Do(req)
+
+	// clear redirect errors and use status code
+	if err != nil && strings.HasSuffix(err.Error(), "redirect") {
+		err = nil
+	}
+
 	if err != nil {
 		log.Println("Error during post request")
 		return err


### PR DESCRIPTION
When POST'ing a sketch for upload to `/data/upload_sketch_silent`, it returns a 302 Found response with a Location of `/cgi-bin/luci/;stok=<stok>/data/upload_sketch_silent`. The Go HTTP client will attempt to do a GET request for this redirect (instead of POST) and get a 401 response because there is no Authentication header in the request.

This change will make `spProgramNetwork` POST a new request to the redirected URL when this condition is encountered.

It would be nice to change the behaviour of the Yun Shield REST service to not redirect, because the sketch data is sent twice over the network. If this is not possible, then we can use this patch instead.

cc/ @facchinm @matteosuppo