### PR TITLE
Only attempt SSH upload on Yun boards

### DIFF
--- a/programmer.go
+++ b/programmer.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -25,10 +26,16 @@ import (
 )
 
 var compiling = false
+var allowedSshBoards = []string{"arduino:avr:yun"}
 
 func colonToUnderscore(input string) string {
 	output := strings.Replace(input, ":", "_", -1)
 	return output
+}
+
+func sshProgramAllowed(boardname string) bool {
+	sort.Strings(allowedSshBoards)
+	return sort.SearchStrings(allowedSshBoards, boardname) != len(allowedSshBoards)
 }
 
 type basicAuthData struct {
@@ -267,8 +274,8 @@ func spProgramRW(portname string, boardname string, filePath string, commandline
 
 	if extraInfo.Network {
 		err = spProgramNetwork(portname, boardname, filePath, extraInfo.Auth)
-		if err != nil && boardname == "arduino:avr:yun" {
-			// http method failed, try ssh upload (Yun only)
+		if err != nil && sshProgramAllowed(boardname) {
+			// http method failed, try ssh upload if allowed
 			err = spProgramSSHNetwork(portname, boardname, filePath, commandline, extraInfo.Auth)
 		}
 	} else {

--- a/programmer.go
+++ b/programmer.go
@@ -267,8 +267,8 @@ func spProgramRW(portname string, boardname string, filePath string, commandline
 
 	if extraInfo.Network {
 		err = spProgramNetwork(portname, boardname, filePath, extraInfo.Auth)
-		if err != nil {
-			// no http method available, try ssh upload
+		if err != nil && boardname == "arduino:avr:yun" {
+			// http method failed, try ssh upload (Yun only)
 			err = spProgramSSHNetwork(portname, boardname, filePath, commandline, extraInfo.Auth)
 		}
 	} else {


### PR DESCRIPTION
Previously SSH uploads were attempted on Yun Shields if the HTTP method failed. However, this causes the following error on non-ATmega32u4 based boards:

```
merge-sketch-with-bootloader.lua /tmp/sketch.hex && /usr/bin/run-avrdude /tmp/sketch.hex
INFO[1635] Command finished with error: Process exited with: 1. Reason was:  () 
```

I think we should only be using SSH for the original Yun board.