### PR TITLE
Download the latest working version of avrdude instead of the latest

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -193,7 +193,12 @@ func checkCmd(m []byte) {
 		args := strings.Split(s, " ")
 		if len(args) > 1 {
 			go func() {
-				err := Tools.Download(args[1], "latest", "keep")
+				var err error
+				if args[1] == "avrdude" {
+					err = Tools.Download(args[1], "6.0.1-arduino5", "keep")
+				} else {
+					err = Tools.Download(args[1], "latest", "keep")
+				}
 				if err != nil {
 					mapD := map[string]string{"DownloadStatus": "Error", "Msg": err.Error()}
 					mapB, _ := json.Marshal(mapD)


### PR DESCRIPTION
Basically the latest version of avrdude doesn't work on windows, so we instead download the latest version we know it's working.

This is a temporary fix until we have a better way to handle things.