### PR TITLE
Fix tool download on 64-bit Windows

### DIFF
--- a/tools/download.go
+++ b/tools/download.go
@@ -51,10 +51,11 @@ type index struct {
 }
 
 var systems = map[string]string{
-	"linuxamd64":  "x86_64-linux-gnu",
-	"linux386":    "i686-linux-gnu",
-	"darwinamd64": "apple-darwin",
-	"windows386":  "i686-mingw32",
+	"linuxamd64":   "x86_64-linux-gnu",
+	"linux386":     "i686-linux-gnu",
+	"darwinamd64":  "apple-darwin",
+	"windows386":   "i686-mingw32",
+	"windowsamd64": "i686-mingw32",
 }
 
 func mimeType(data []byte) (string, error) {


### PR DESCRIPTION
When compiling the agent on 64-bit Windows, tool downloads fail, as no
64-bit Windows builds of the tools are available (as far as I can tell).
This commit directs agents compiled for 64-bit Windows to just download
the 32-bit Windows variant of the tool.

Please note that while I have confirmed that this fix works for me (by successfully downloading bossac and uploading a program to my Arduino Due), I'm not sure if there are any side-effects of this change that I'm not aware of. Please let me know if there's anything wrong with this pull request.

Close #199.