### PR TITLE
Replace info in commandline about password

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -54,6 +54,7 @@ type Extra struct {
 func PartiallyResolve(board, file, commandline string, extra Extra, t Locater) (string, error) {
 	commandline = strings.Replace(commandline, "{build.path}", filepath.ToSlash(filepath.Dir(file)), -1)
 	commandline = strings.Replace(commandline, "{build.project_name}", strings.TrimSuffix(filepath.Base(file), filepath.Ext(filepath.Base(file))), -1)
+	commandline = strings.Replace(commandline, "{network.password}", extra.Auth.Password, -1)
 
 	if extra.Verbose == true {
 		commandline = strings.Replace(commandline, "{upload.verbose}", extra.ParamsVerbose, -1)


### PR DESCRIPTION
To upload to a mkr1000 via wifi you actually have to send a command to arduinoOta, so it's basically a serial upload. But you need to specify the password of the board, so here's this commit that lets you do it

Signed-off-by: Matteo Suppo <matteo.suppo@gmail.com>