### PR TITLE
Remove unnecessary CORS origins

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,10 +206,6 @@ func main() {
 
 			extraOriginStr := "https://create.arduino.cc, http://create.arduino.cc, https://create-dev.arduino.cc, http://create-dev.arduino.cc, https://create-intel.arduino.cc, http://create-intel.arduino.cc"
 
-			for i := 8990; i < 9001; i++ {
-				extraOriginStr = extraOriginStr + ", http://localhost:" + strconv.Itoa(i) + ", https://localhost:" + strconv.Itoa(i)
-			}
-
 			r.Use(cors.Middleware(cors.Config{
 				Origins:         *origins + ", " + extraOriginStr,
 				Methods:         "GET, PUT, POST, DELETE",


### PR DESCRIPTION
This removes the code that adds various `localhost` addresses as CORS origins. The commit message contains the justification for that.

I might have missed something. Please let me know, if that is the case!