### PR TITLE
expose origin end update flags when calling /info

### DIFF
--- a/info.go
+++ b/info.go
@@ -18,6 +18,8 @@ func infoHandler(c *gin.Context) {
 		"https":   "https://localhost" + portSSL,
 		"ws":      "ws://" + host + port,
 		"wss":     "wss://localhost" + portSSL,
+		"origins": origins,
+		"update_url": updateUrl,
 	})
 }
 


### PR DESCRIPTION
Exposing config.ini properties to let frontend perform configuration checks