### PR TITLE
Create parent folder for files in archives

### DIFF
--- a/tools/download.go
+++ b/tools/download.go
@@ -419,6 +419,11 @@ func extractTarGz(body []byte, location string) (string, error) {
 		path := filepath.Join(location, strings.Replace(header.Name, basedir, "", -1))
 		info := header.FileInfo()
 
+		// Create parent folder
+		if err = os.MkdirAll(filepath.Dir(path), info.Mode()); err != nil {
+			return location, err
+		}
+
 		if info.IsDir() {
 			if err = os.MkdirAll(path, info.Mode()); err != nil {
 				return location, err

--- a/tools/download.go
+++ b/tools/download.go
@@ -319,6 +319,9 @@ func stringInSlice(str string, list []string) bool {
 }
 
 func findBaseDir(dirList []string) string {
+	if len(dirList) == 1 {
+		return filepath.Dir(dirList[0]) + "/"
+	}
 	baseDir := ""
 	// https://github.com/backdrop-ops/contrib/issues/55#issuecomment-73814500
 	dontdiff := []string{"pax_global_header"}

--- a/tools/download_test.go
+++ b/tools/download_test.go
@@ -1,0 +1,24 @@
+package tools
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_findBaseDir(t *testing.T) {
+	cases := []struct {
+		dirList []string
+		want    string
+	}{
+		{[]string{"bin/bossac"}, "bin/"},
+		{[]string{"bin/", "bin/bossac"}, "bin/"},
+		{[]string{"bin/", "bin/bossac", "example"}, ""},
+	}
+	for _, tt := range cases {
+		t.Run(fmt.Sprintln(tt.dirList), func(t *testing.T) {
+			if got := findBaseDir(tt.dirList); got != tt.want {
+				t.Errorf("findBaseDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -51,10 +51,11 @@ type Extra struct {
 
 // PartiallyResolve replaces some symbols in the commandline with the appropriate values
 // it can return an error when looking a variable in the Locater
-func PartiallyResolve(board, file, commandline string, extra Extra, t Locater) (string, error) {
+func PartiallyResolve(board, file, platformPath, commandline string, extra Extra, t Locater) (string, error) {
 	commandline = strings.Replace(commandline, "{build.path}", filepath.ToSlash(filepath.Dir(file)), -1)
 	commandline = strings.Replace(commandline, "{build.project_name}", strings.TrimSuffix(filepath.Base(file), filepath.Ext(filepath.Base(file))), -1)
 	commandline = strings.Replace(commandline, "{network.password}", extra.Auth.Password, -1)
+	commandline = strings.Replace(commandline, "{runtime.platform.path}", platformPath, -1)
 
 	if extra.Verbose == true {
 		commandline = strings.Replace(commandline, "{upload.verbose}", extra.ParamsVerbose, -1)


### PR DESCRIPTION
Ensures that the parent folder of a file exists even if the tar.gz doesn't explicitely specify the header for that folder.