### PR TITLE
Set correct permissions when downloading tool [WE-44]

### DIFF
--- a/tools/download.go
+++ b/tools/download.go
@@ -423,7 +423,8 @@ func extractTarGz(body []byte, location string) (string, error) {
 		info := header.FileInfo()
 
 		// Create parent folder
-		if err = os.MkdirAll(filepath.Dir(path), info.Mode()); err != nil {
+		dirmode := info.Mode() | os.ModeDir | 0700
+		if err = os.MkdirAll(filepath.Dir(path), dirmode); err != nil {
 			return location, err
 		}
 
@@ -513,6 +514,12 @@ func extractBz2(body []byte, location string) (string, error) {
 
 		path := filepath.Join(location, strings.Replace(header.Name, basedir, "", -1))
 		info := header.FileInfo()
+
+		// Create parent folder
+		dirmode := info.Mode() | os.ModeDir | 0700
+		if err = os.MkdirAll(filepath.Dir(path), dirmode); err != nil {
+			return location, err
+		}
 
 		if info.IsDir() {
 			if err = os.MkdirAll(path, info.Mode()); err != nil {


### PR DESCRIPTION
The extraction of some tools failed because the parent folder of
some files wasn't created with useful permissions.

Here we correctly set the permission such as the folder has
exec and write permission for the current user

A more long-term solution would be to offload these extractions to a dedicated library, but first we need to merge #254 and to do that jenkins must be configured to use go 1.10