### PR TITLE
[WE-158] Linux arm tool fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 arduino-create-agent
 ====================
 
@@ -374,6 +375,8 @@ The results of the upload will be delivered via websocket with messages that loo
 ---
 
 ## Development
+
+Please remember that for compile the project, you need go version <= 1.8.7 (more recent versions are not supported for compile)
 
 To clone the repository, run the following command:
 ```

--- a/tools/download.go
+++ b/tools/download.go
@@ -56,6 +56,7 @@ var systems = map[string]string{
 	"darwinamd64":  "apple-darwin",
 	"windows386":   "i686-mingw32",
 	"windowsamd64": "i686-mingw32",
+	"linuxarm":     "arm-linux-gnueabihf",
 }
 
 func mimeType(data []byte) (string, error) {


### PR DESCRIPTION
fixes #260 
- Adds map entry to support arm tooling
- add go version info in readme under "development" section
Tested on a raspberry pi 3 model B v1.2 and an Arduino Mega