### PR TITLE
[WE-205] sanitize paths when replacing {runtime.platform.path}

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -55,7 +55,7 @@ func PartiallyResolve(board, file, platformPath, commandline string, extra Extra
 	commandline = strings.Replace(commandline, "{build.path}", filepath.ToSlash(filepath.Dir(file)), -1)
 	commandline = strings.Replace(commandline, "{build.project_name}", strings.TrimSuffix(filepath.Base(file), filepath.Ext(filepath.Base(file))), -1)
 	commandline = strings.Replace(commandline, "{network.password}", extra.Auth.Password, -1)
-	commandline = strings.Replace(commandline, "{runtime.platform.path}", platformPath, -1)
+	commandline = strings.Replace(commandline, "{runtime.platform.path}", filepath.ToSlash(platformPath), -1)
 
 	if extra.Verbose == true {
 		commandline = strings.Replace(commandline, "{upload.verbose}", extra.ParamsVerbose, -1)


### PR DESCRIPTION
This PR fixes a path generation in upload command in windows environment:

Error has this form for Arduino WiFi Rev2:
`Flashing with command:C:/Users/per/.arduino-create/arduino/avrdude/6.3.0-arduino14/bin/avrdude.exe -CC:/Users/per/.arduino-create/arduino/avrdude/6.3.0-arduino14/etc/avrdude.conf -v -patmega4809 -cxplainedmini_updi -Pusb -b115200 -e -D -Uflash:w:C:/Users/per/AppData/Local/Temp/arduino-create-agent248491772/sketch_feb28a.hex:i -Ufuses:w:C:UsersperAppDataLocalTempextrafiles293253675/fuses/fuses_4809.bin:r`

`-Ufuses:w:C:UsersperAppDataLocalTempextrafiles293253675/fuses/fuses_4809.bin:r`

should be

`-Ufuses:w:C:/Users/per/AppData/Local/Temp/extrafiles293253675/fuses/fuses_4809.bin:r`

this has properly tested on all 3 platforms 