### PR TITLE
Fix duplicate tool bug

### DIFF
--- a/v2/pkgs/indexes.go
+++ b/v2/pkgs/indexes.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/arduino/arduino-create-agent/gen/indexes"
 	"github.com/sirupsen/logrus"
@@ -77,13 +78,17 @@ func (c *Indexes) List(context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	res := make([]string, len(files))
-	for i, file := range files {
+	res := []string{}
+	for _, file := range files {
+		// Select only files that begin with http
+		if !strings.HasPrefix(file.Name(), "http") {
+			continue
+		}
 		path, err := url.PathUnescape(file.Name())
 		if err != nil {
 			c.Log.Warn(err)
 		}
-		res[i] = path
+		res = append(res, path)
 	}
 
 	return res, nil

--- a/v2/pkgs/indexes_test.go
+++ b/v2/pkgs/indexes_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -27,6 +28,9 @@ func TestIndexes(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
+
+	// Create extraneous folder in temp folder
+	os.MkdirAll(filepath.Join(tmp, "arduino"), 0755)
 
 	service := pkgs.Indexes{
 		Folder: tmp,

--- a/v2/pkgs/tools.go
+++ b/v2/pkgs/tools.go
@@ -169,8 +169,15 @@ func (c *Tools) install(ctx context.Context, path, url, checksum string) (*tools
 	var buffer bytes.Buffer
 	reader := io.TeeReader(res.Body, &buffer)
 
+	// Cleanup
+	err = os.RemoveAll(filepath.Join(c.Folder, path))
+	if err != nil {
+		return nil, err
+	}
+
 	err = extract.Archive(ctx, reader, c.Folder, rename(path))
 	if err != nil {
+		os.RemoveAll(path)
 		return nil, err
 	}
 

--- a/v2/pkgs/tools_test.go
+++ b/v2/pkgs/tools_test.go
@@ -89,6 +89,16 @@ func TestTools(t *testing.T) {
 		t.Fatalf("expected %d == %d (%s)", len(installed), 1, "len(installed)")
 	}
 
+	// Install the tool again
+	_, err = service.Install(ctx, &tools.ToolPayload{
+		Packager: "arduino",
+		Name:     "avrdude",
+		Version:  "6.0.1-arduino2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Remove tool
 	_, err = service.Remove(ctx, &tools.ToolPayload{
 		Packager: "arduino",


### PR DESCRIPTION
When you attempt to download the same tool twice it can fail
if there are symlinks inside the archive. By removing the folder
we make sure we start from scratch every time

Also indexes were behaving badly attempting to parse extraneous files