### PR TITLE
add ci step to upload artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run unit tests
         run: task test-unit
 
+      - name: Check dir content
+        run: ls
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: arduino-create-agent-${{ matrix.operating-system }}
-          path: arduino-create-agent
+          path: arduino-create-agent*
           if-no-files-found: error
 
       # - name: Send unit tests coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Run unit tests
         run: task test-unit
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: arduino-create-agent-${{ matrix.operating-system }}
+          path: arduino-create-agent
+          if-no-files-found: error
+
       # - name: Send unit tests coverage to Codecov
       #   if: >
       #     matrix.operating-system == 'ubuntu-latest' &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Run unit tests
         run: task test-unit
 
-      - name: Check dir content
-        run: ls
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
CI feature
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
no artifacts is uploaded by the ci
* **What is the new behavior?**
<!-- if this is a feature change -->
artifacts of the compiled executables are uploaded
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
