### PR TITLE
fix win executable crashing (add manifest to the executable during compile)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
 
       - name: Build the Agent
         run: task build
+        if: matrix.operating-system != 'windows-latest'
+
+      - name: Build the Agent for win
+        run: task build-win
+        if: matrix.operating-system == 'windows-latest'
 
       - name: Run unit tests
         run: task test-unit

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,14 @@ tasks:
     cmds:
       - go build -v -i {{.LDFLAGS}}
 
+  build-win:
+    desc: Build the project for win
+    cmds:
+      - go get github.com/akavel/rsrc
+      - rsrc -arch=386 -manifest=manifest.xml
+      - go build -v -i {{.WIN_LDFLAGS}}
+      - rm rsrc.syso
+
   test:
     desc: Run the full testsuite, `legacy` will be skipped
     cmds:
@@ -39,6 +47,7 @@ vars:
   DEFAULT_TARGETS:
     sh: echo `go list ./... | grep -v 'arduino-create-agent/gen/' | tr '\n' ' '`
   # build vars
+  WIN_FLAGS: -H=windowsgui
   COMMIT:
     sh: echo ${TRAVIS_COMMIT:-`git log -n 1 --format=%h`}
   TAG:
@@ -46,6 +55,10 @@ vars:
   LDFLAGS: >
     -ldflags '-X main.version={{.TAG}}
     -X main.git_revision={{.COMMIT}}'
+  WIN_LDFLAGS: >
+    -ldflags '-X main.version={{.TAG}}
+    -X main.git_revision={{.COMMIT}}
+    {{.WIN_FLAGS}}'
   # test vars
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
   TEST_VERSIONSTRING: "0.0.0-alpha"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/arduino/arduino-create-agent
 go 1.14
 
 require (
+	github.com/akavel/rsrc v0.9.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/codeclysm/extract v2.0.0+incompatible
 	github.com/creack/goselect v0.0.0-20180501195510-58854f77ee8d

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/akavel/rsrc v0.9.0 h1:HwUDC0+tMFWqN4D5G+o5siGD4oVsC3jn6zM8ocjc3nY=
+github.com/akavel/rsrc v0.9.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/codeclysm/extract v2.0.0+incompatible h1:+b4WsD7YuZ5u3iW5T5TWbO764zUyEpQZSH5tZbjAxXQ=


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
the windows executable is not working and it's crashing with `TTM_ADDTOOL failed` error
* **What is the new behavior?**
<!-- if this is a feature change -->
Now windows executable should work correctly
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->

