### PR TITLE
Publish release on arduino download servers 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,21 +351,32 @@ jobs:
           cat ArduinoCreateAgent-osx/*.tar | tar -xvf - -i -C release/
           mv -v ArduinoCreateAgent-windows/* release/
 
-      - name: Create Github Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: "THIS IS A TEST RELEASE"
-          draft: false
-          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+      # - name: Create Github Release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: ${{ github.ref }}
+      #     release_name: ${{ github.ref }}
+      #     body: "THIS IS A TEST RELEASE"
+      #     draft: false
+      #     prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
 
-      - name: Upload release files on Github
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }}
-          file_glob: true  # If set to true, the file argument can be a glob pattern
-          file: release/*
+      # - name: Upload release files on Github
+      #   uses: svenstaro/upload-release-action@v2
+      #   with:
+      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+      #     tag: ${{ github.ref }}
+      #     file_glob: true  # If set to true, the file argument can be a glob pattern
+      #     file: release/*
+
+      - name: Upload release files on Arduino downloads servers
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: "release/*"
+          PLUGIN_TARGET: "/tmp/CreateBridge/staging/"
+          PLUGIN_STRIP_PREFIX: "release/"
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        if: steps.prerelease.outputs.IS_PRE != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,6 +334,14 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2 # download all the artifacts
 
+      - name: Identify Prerelease
+        # This is a workaround while waiting for create-release action to implement auto pre-release based on tag
+        id: prerelease
+        run: |
+          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.1.0.zip
+          unzip -p /tmp/3.1.0.zip semver-tool-3.1.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          if [[ $(/tmp/semver get prerel ${GITHUB_REF/refs\/tags\//}) ]]; then echo "::set-output name=IS_PRE::true"; fi
+
       #  mandatory step because upload-release-action does not support multiple folders
       - name: prepare artifacts for the release
         run: |
@@ -352,7 +360,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: "THIS IS A TEST RELEASE"
           draft: false
-          prerelease: true  # see later how to handle this (maybe just a check on "-dev" will be sufficient)
+          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
 
       - name: Upload release files on Github
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,7 @@ jobs:
           chmod -v +x ArduinoCreateAgent-linux-x64/*.run
           mv -v ArduinoCreateAgent-linux-x64/* release/
           cat ArduinoCreateAgent-osx/*.tar | tar -xvf - -i -C release/
+          rm _ArduinoCreateAgent*.dmg
           mv -v ArduinoCreateAgent-windows/* release/
 
       # - name: Create Github Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
           chmod -v +x ArduinoCreateAgent-linux-x64/*.run
           mv -v ArduinoCreateAgent-linux-x64/* release/
           cat ArduinoCreateAgent-osx/*.tar | tar -xvf - -i -C release/
-          rm _ArduinoCreateAgent*.dmg
+          rm -v release/_ArduinoCreateAgent*.dmg
           mv -v ArduinoCreateAgent-windows/* release/
 
       # - name: Create Github Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: code-sign-mac-installers
     env:
-      PLUGIN_TARGET: "/tmp/CreateBridgeStable/"  # TODO remove tmp
+      PLUGIN_TARGET: "/CreateBridgeStable/"
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -372,24 +372,24 @@ jobs:
           rm -v release/._ArduinoCreateAgent*.dmg
           mv -v ArduinoCreateAgent-windows/* release/
 
-      # - name: Create Github Release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     tag_name: ${{ github.ref }}
-      #     release_name: ${{ github.ref }}
-      #     body: "THIS IS A TEST RELEASE"
-      #     draft: false
-      #     prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+      - name: Create Github Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ""
+          draft: false
+          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
 
-      # - name: Upload release files on Github
-      #   uses: svenstaro/upload-release-action@v2
-      #   with:
-      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-      #     tag: ${{ github.ref }}
-      #     file_glob: true  # If set to true, the file argument can be a glob pattern
-      #     file: release/*
+      - name: Upload release files on Github
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          file_glob: true  # If set to true, the file argument can be a glob pattern
+          file: release/*
 
       - name: Upload release files on Arduino downloads servers
         run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.PLUGIN_TARGET }} --include "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,12 +372,9 @@ jobs:
       #     file: release/*
 
       - name: Upload release files on Arduino downloads servers
-        uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "release/*"
           PLUGIN_TARGET: "/tmp/CreateBridge/staging/"
-          PLUGIN_STRIP_PREFIX: "release/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.PLUGIN_TARGET }} --include "*"
         if: steps.prerelease.outputs.IS_PRE != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
           chmod -v +x ArduinoCreateAgent-linux-x64/*.run
           mv -v ArduinoCreateAgent-linux-x64/* release/
           cat ArduinoCreateAgent-osx/*.tar | tar -xvf - -i -C release/
-          rm -v release/_ArduinoCreateAgent*.dmg
+          rm -v release/._ArduinoCreateAgent*.dmg
           mv -v ArduinoCreateAgent-windows/* release/
 
       # - name: Create Github Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,9 +378,3 @@ jobs:
       - name: Upload release files on Arduino downloads servers
         run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.PLUGIN_TARGET }} --include "*"
         if: steps.prerelease.outputs.IS_PRE != 'true'
-
-      - name: Update release file version
-        run: |
-          echo '{"Version": "'${GITHUB_REF##*/}'"}' > /tmp/installer-version
-          aws s3 cp /tmp/installer-version s3://arduino-create-static/agent-metadata/agent-installer-version.json
-        if: steps.prerelease.outputs.IS_PRE != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,6 +381,6 @@ jobs:
 
       - name: Update release file version
         run: |
-          echo '{"Version": "${GITHUB_REF##*/}"}' > /tmp/installer-version
+          echo '{"Version": "'${GITHUB_REF##*/}'"}' > /tmp/installer-version
           aws s3 cp /tmp/installer-version s3://arduino-create-static/agent-metadata/agent-installer-version.json
         if: steps.prerelease.outputs.IS_PRE != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
     env:
       # vars used by installbuilder
       INSTALLBUILDER_PATH: "/opt/installbuilder-20.9.0/bin/builder"
-      INSTALLER_VARS: "project.outputDirectory=$PWD project.version=${GITHUB_REF##*/} workspace=$PWD realname=Arduino_Create_Bridge"
+      # INSTALLER_VARS: "project.outputDirectory=$PWD project.version=${GITHUB_REF##*/} workspace=$PWD realname=Arduino_Create_Bridge"
       # vars passed to installbuilder to install https certs automatically
       CERT_INSTALL: "ask_certificates_install=CI"  # win(edge),mac(safari)
       NO_CERT_INSTALL: "ask_certificates_install=CS"  # linux
@@ -185,6 +185,16 @@ jobs:
       image: floydpink/ubuntu-install-builder:20.9.0
 
     steps:
+
+        # workaround to strip bugfix number from semver (only to make 1.1 release) I will change this in the future
+      - name: Set version env vars
+        # VERSION will be available only in the next step
+        run: |
+          echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Set installer env vars
+        run: |
+          echo INSTALLER_VARS="project.outputDirectory=$PWD project.version=${VERSION%.*} workspace=$PWD realname=Arduino_Create_Bridge" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -225,22 +235,22 @@ jobs:
         # installbuilder reads the env vars with certs paths and use it to sign the installer.
       - name: Launch Bitrock installbuilder-20 with CERT_INSTALL && CHOICE_CERT_INSTALL
         run: |
-          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} ${{ env.CERT_INSTALL }}
-          mv -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CI${{matrix.installer-extension}} ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-${{matrix.browser}}${{matrix.installer-extension}}
-          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} ${{ env.CHOICE_CERT_INSTALL }}
-          cp -vr ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-chrome${{matrix.installer-extension}}
-          mv -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-firefox${{matrix.installer-extension}}
-          rm -r ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-C*
+          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${INSTALLER_VARS} ${{ env.CERT_INSTALL }}
+          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CI${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-${{matrix.browser}}${{matrix.installer-extension}}
+          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${INSTALLER_VARS} ${{ env.CHOICE_CERT_INSTALL }}
+          cp -vr ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-chrome${{matrix.installer-extension}}
+          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-firefox${{matrix.installer-extension}}
+          rm -r ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-C*
         if: matrix.operating-system == 'windows-latest' || matrix.operating-system == 'macos-latest'
 
         # linux
       - name: Launch Bitrock installbuilder-20 with NO_CERT_INSTALL
         run: |
-          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} ${{ env.NO_CERT_INSTALL }}
-          cp -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CS.run ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-chrome.run
-          mv -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CS.run ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-firefox.run
-          cp -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CS.tar.gz ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-chrome.tar.gz
-          mv -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CS.tar.gz ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-firefox.tar.gz
+          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${INSTALLER_VARS} ${{ env.NO_CERT_INSTALL }}
+          cp -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CS.run ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-chrome.run
+          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CS.run ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-firefox.run
+          cp -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CS.tar.gz ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-chrome.tar.gz
+          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CS.tar.gz ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-firefox.tar.gz
         if: matrix.operating-system == 'ubuntu-latest'
 
       - name: Upload artifacts
@@ -267,9 +277,15 @@ jobs:
           name: ArduinoCreateAgent-osx
           path: ArduinoCreateAgent-osx
 
+        # workaround to strip bugfix number from semver (only to make 1.1 release) I will change this in the future
+      - name: Set version env vars
+        # VERSION will be available only in the next step
+        run: |
+          echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
         # zip artifacts do not mantain executable permission
       - name: Make executable
-        run: chmod -v +x ArduinoCreateAgent-osx/ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.app/Contents/MacOS/*
+        run: chmod -v +x ArduinoCreateAgent-osx/ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.app/Contents/MacOS/*
 
       - name: Import Code-Signing Certificates
         env:
@@ -292,7 +308,7 @@ jobs:
         # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
         run: |
           cat > gon.config_installer.hcl <<EOF
-          source = ["ArduinoCreateAgent-osx/ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.app"]
+          source = ["ArduinoCreateAgent-osx/ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.app"]
           bundle_id = "cc.arduino.arduino-agent-installer"
 
           sign {
@@ -300,7 +316,7 @@ jobs:
           }
 
           dmg {
-            output_path = "ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.dmg"
+            output_path = "ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.dmg"
             volume_name = "ArduinoCreateAgent"
           }
           EOF
@@ -310,13 +326,13 @@ jobs:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         run: |
-          echo "gon will notarize executable in ArduinoCreateAgent-osx/ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.app"
+          echo "gon will notarize executable in ArduinoCreateAgent-osx/ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.app"
           gon -log-level=debug -log-json gon.config_installer.hcl
         timeout-minutes: 30
 
       #  tar dmg file to keep executable permission
       - name: Tar files to keep permissions
-        run: tar -cvf ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.tar ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.dmg
+        run: tar -cvf ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.tar ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.dmg
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,10 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: code-sign-mac-installers
+    env:
+      PLUGIN_TARGET: "/tmp/CreateBridgeStable/"  # TODO remove tmp
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:
 
@@ -372,9 +376,11 @@ jobs:
       #     file: release/*
 
       - name: Upload release files on Arduino downloads servers
-        env:
-          PLUGIN_TARGET: "/tmp/CreateBridge/staging/"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.PLUGIN_TARGET }} --include "*"
+        if: steps.prerelease.outputs.IS_PRE != 'true'
+
+      - name: Update release file version
+        run: |
+          echo '{"Version": "${GITHUB_REF##*/}"}' > /tmp/installer-version
+          aws s3 cp /tmp/installer-version s3://arduino-create-static/agent-metadata/agent-installer-version.json
         if: steps.prerelease.outputs.IS_PRE != 'true'


### PR DESCRIPTION
just like the arduino-cli does

**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
feature
- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->
Add steps to the `release.yml` workflow:
1. to detect if a release is a prerelease or not :question: 
2. to publish release installers to arduino servers automatically (in case of a full release) :arrow_down_small: 
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
nope
* **Other information**:
<!-- Any additional information that could help the review process -->
