### PR TITLE
revert to building minimum version for mac to 10.9 & separate step fo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Run unit tests
         run: task test-unit
 
-      - name: Build the Agent
+      - name: Build the Agent for linux
         run: task build
-        if: matrix.operating-system != 'windows-2019'
+        if: matrix.operating-system == 'ubuntu-18.04'
 
         # build the agent without GUI support (no tray icon)
       - name: Build the Agent-cli
@@ -76,6 +76,12 @@ jobs:
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: task build-win32
         if: matrix.operating-system == 'windows-2019'
+
+      - name: Build the Agent for macos
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.9 # minimum supported version for mac
+        run: task build
+        if: matrix.operating-system == 'macos-10.15'
 
         # config.ini is required by the executable when it's run
       - name: Upload artifacts


### PR DESCRIPTION
…r mac

**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The agent gives an error when is installed on older version of MacOS

![image](https://user-images.githubusercontent.com/34278123/101933726-e376f500-3bdc-11eb-9f6d-27e1cff680ad.png)

* **What is the new behavior?**
<!-- if this is a feature change -->
Minimum mac version lowered to 10.9

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
nope, the agent should stay compatible with every platform as before.
* **Other information**:
<!-- Any additional information that could help the review process -->
