### PR TITLE
CI polishing, add win64, update macOS min version 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         run: |
-          echo "gon will notarize executable in "arduino-create-agent-${{ env.RUNS_ON }}/arduino-create-agent"
+          echo "gon will notarize executable in arduino-create-agent-${{ env.RUNS_ON }}/arduino-create-agent"
           gon -log-level=debug -log-json gon.config.hcl
         timeout-minutes: 30
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
         operating-system: [ubuntu-18.04, windows-2019, macos-10.15]
 
     runs-on: ${{ matrix.operating-system }}
+    env:
+      TAG_VERSION: ${GITHUB_REF##*/} # will be available to all steps and will be used by task build
 
     steps:
       - name: Disable EOL conversions
@@ -53,7 +55,7 @@ jobs:
         run: task test-unit
 
       - name: Build the Agent for linux
-        run: task build
+        run: task build 
         if: matrix.operating-system == 'ubuntu-18.04'
 
         # build the agent without GUI support (no tray icon)
@@ -61,29 +63,16 @@ jobs:
         run: task build-cli
         if: matrix.operating-system == 'ubuntu-18.04'
 
-        # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
-        # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
-      - name: Download tool to embed manifest in win binary
-        run: |
-          go get github.com/akavel/rsrc
-        if: matrix.operating-system == 'windows-2019'
-
         # building the agent for win requires a different task because of an extra flag
       - name: Build the Agent for win32
         env:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
-        run: |
-          rsrc -arch 386 -manifest manifest.xml
-          task build-win
-          rm *.syso
+        run: task build-win
         if: matrix.operating-system == 'windows-2019'
 
       - name: Build the Agent for win64
-        run: |
-          rsrc -arch amd64 -manifest manifest.xml
-          task build-win
-          rm *.syso
+        run: task build-win # GOARCH=amd64 by default on the runners
         if: matrix.operating-system == 'windows-2019'
 
       - name: Build the Agent for macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,10 @@ jobs:
         if: matrix.operating-system == 'ubuntu-18.04'
 
         # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
-        # rsrc will produce *.syso files that should get automatically recognized by go build command and linked into an executable.
-      - name: Embed manifest in win binary
+        # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
+      - name: Download tool to embed manifest in win binary
         run: |
           go get github.com/akavel/rsrc
-          rsrc -arch 386 -manifest manifest.xml
         if: matrix.operating-system == 'windows-2019'
 
         # building the agent for win requires a different task because of an extra flag
@@ -74,7 +73,17 @@ jobs:
         env:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
-        run: task build-win32
+        run: |
+          rsrc -arch 386 -manifest manifest.xml
+          task build-win
+          rm *.syso
+        if: matrix.operating-system == 'windows-2019'
+
+      - name: Build the Agent for win64
+        run: |
+          rsrc -arch amd64 -manifest manifest.xml
+          task build-win
+          rm *.syso
         if: matrix.operating-system == 'windows-2019'
 
       - name: Build the Agent for macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,13 @@ jobs:
   build:
     strategy:
       matrix:
-        operating-system: [ubuntu-18.04, windows-2019, macos-10.15]
+        include:
+        - operating-system: ubuntu-18.04
+        - operating-system: windows-2019
+          arch: 386
+        - operating-system: windows-2019
+          arch: amd64
+        - operating-system: macos-10.15
 
     runs-on: ${{ matrix.operating-system }}
     env:
@@ -75,11 +81,11 @@ jobs:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: task build-win
-        if: matrix.operating-system == 'windows-2019'
+        if: matrix.operating-system == 'windows-2019' && matrix.arch == '386'
 
       - name: Build the Agent for win64
         run: task build-win # GOARCH=amd64 by default on the runners
-        if: matrix.operating-system == 'windows-2019'
+        if: matrix.operating-system == 'windows-2019' && matrix.arch == 'amd64'
 
       - name: Build the Agent for macos
         env:
@@ -93,7 +99,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: arduino-create-agent-${{ matrix.operating-system }}
+          name: arduino-create-agent-${{ matrix.operating-system }}${{ matrix.arch }}
           path: |
             arduino-create-agent*
             config.ini

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,12 @@ jobs:
         run: task build-cli
         if: matrix.operating-system == 'ubuntu-18.04'
 
+        # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
+        # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
+      - name: Download tool to embed manifest in win binary
+        run: go get github.com/akavel/rsrc
+        if: matrix.operating-system == 'windows-2019'
+
         # building the agent for win requires a different task because of an extra flag
       - name: Build the Agent for win32
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.14"
 
         # dependencies used for compiling the GUI
       - name: Install Dependencies (Linux)
@@ -88,9 +88,9 @@ jobs:
 
       - name: Build the Agent for macos
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.12 # minimum supported version for mac
-          CGO_CFLAGS: -mmacosx-version-min=10.12
-          CGO_LDFLAGS: -mmacosx-version-min=10.12
+          MACOSX_DEPLOYMENT_TARGET: 10.11 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.11
+          CGO_LDFLAGS: -mmacosx-version-min=10.11
         run: task build
         if: matrix.operating-system == 'macos-10.15'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,6 @@ jobs:
       RUNS_ON: macos-10.15  # used to parametrize filenames
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          repository: 'bcmi-labs/arduino-create-agent-installer' # the repo which contains gon.config.hcl
-          token: ${{ secrets.ARDUINO_CREATE_AGENT_CI_PAT }}
-
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
@@ -141,14 +135,29 @@ jobs:
           wget -q https://github.com/mitchellh/gon/releases/download/v0.2.3/gon_macos.zip
           unzip gon_macos.zip -d /usr/local/bin
 
+      - name: Write gon config to file
+        # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
+        run: |
+          cat > gon.config.hcl <<EOF
+          source = ["arduino-create-agent-${{ env.RUNS_ON }}/arduino-create-agent"]
+          bundle_id = "cc.arduino.arduino-agent"
+          sign {
+            application_identity = "Developer ID Application: ARDUINO SA (7KT7ZWMCJT)"
+          }
+          # Ask Gon for zip output to force notarization process to take place.
+          # The CI will ignore the zip output, using the signed binary only.
+          zip {
+            output_path = "arduino-create-agent.zip"
+          }
+          EOF
+
       - name: Code sign and notarize app
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         run: |
+          echo "gon will notarize executable in "arduino-create-agent-${{ env.RUNS_ON }}/arduino-create-agent"
           gon -log-level=debug -log-json gon.config.hcl
-          # gon will notarize executable in "arduino-create-agent-${{ env.RUNS_ON }}/arduino-create-agent
-          # The CI will ignore the zip output, using the signed binary only.
         timeout-minutes: 30
 
         # This step will overwrite the non signed mac artifact (arduino-create-agent-${{ env.RUNS_ON }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
         include:
         - operating-system: ubuntu-18.04
         - operating-system: windows-2019
-          arch: 386
+          arch: -386
         - operating-system: windows-2019
-          arch: amd64
+          arch: -amd64
         - operating-system: macos-10.15
 
     runs-on: ${{ matrix.operating-system }}
@@ -81,11 +81,11 @@ jobs:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: task build-win
-        if: matrix.operating-system == 'windows-2019' && matrix.arch == '386'
+        if: matrix.operating-system == 'windows-2019' && matrix.arch == '-386'
 
       - name: Build the Agent for win64
         run: task build-win # GOARCH=amd64 by default on the runners
-        if: matrix.operating-system == 'windows-2019' && matrix.arch == 'amd64'
+        if: matrix.operating-system == 'windows-2019' && matrix.arch == '-amd64'
 
       - name: Build the Agent for macos
         env:
@@ -192,13 +192,20 @@ jobs:
     strategy:
       fail-fast: false  # if one os is failing continue nonetheless
       matrix:  # used to generate installers for different OS and not for runs-on
-        operating-system: [ubuntu-18.04, windows-2019, macos-10.15]
 
         include:
           - operating-system: ubuntu-18.04
             install-builder-name: linux-x64
             executable-path: artifacts/linux-amd64/
           - operating-system: windows-2019
+            arch: -386
+            browser: edge
+            install-builder-name: windows
+            executable-path: artifacts/windows/
+            extension: .exe
+            installer-extension: .exe
+          - operating-system: windows-2019
+            arch: -amd64
             browser: edge
             install-builder-name: windows
             executable-path: artifacts/windows/
@@ -234,7 +241,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: arduino-create-agent-${{ matrix.operating-system }}
+          name: arduino-create-agent-${{ matrix.operating-system }}${{ matrix.arch }}
           path: ${{ matrix.executable-path }}  # path expected by installbuilder
 
         # zip artifacts do not mantain executable permission
@@ -265,10 +272,10 @@ jobs:
       - name: Launch Bitrock installbuilder-20 with CERT_INSTALL && CHOICE_CERT_INSTALL
         run: |
           ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${INSTALLER_VARS} ${{ env.CERT_INSTALL }}
-          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CI${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-${{matrix.browser}}${{matrix.installer-extension}}
+          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CI${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-${{matrix.browser}}${{matrix.installer-extension}}
           ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${INSTALLER_VARS} ${{ env.CHOICE_CERT_INSTALL }}
-          cp -vr ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-chrome${{matrix.installer-extension}}
-          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-firefox${{matrix.installer-extension}}
+          cp -vr ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-chrome${{matrix.installer-extension}}
+          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-firefox${{matrix.installer-extension}}
           rm -r ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-C*
         if: matrix.operating-system == 'windows-2019' || matrix.operating-system == 'macos-10.15'
 
@@ -285,7 +292,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: ArduinoCreateAgent-${{ matrix.install-builder-name }}
+          name: ArduinoCreateAgent-${{ matrix.install-builder-name }}${{ matrix.arch }}
           path: ArduinoCreateAgent*
           if-no-files-found: error
 
@@ -399,7 +406,7 @@ jobs:
           mv -v ArduinoCreateAgent-linux-x64/* release/
           cat ArduinoCreateAgent-osx/*.tar | tar -xvf - -i -C release/
           rm -v release/._ArduinoCreateAgent*.dmg
-          mv -v ArduinoCreateAgent-windows/* release/
+          mv -v ArduinoCreateAgent-windows*/* release/
 
       - name: Create Github Release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,9 @@ jobs:
 
       - name: Build the Agent for macos
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.9 # minimum supported version for mac
+          MACOSX_DEPLOYMENT_TARGET: 10.12 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.12
+          CGO_LDFLAGS: -mmacosx-version-min=10.12
         run: task build
         if: matrix.operating-system == 'macos-10.15'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,10 @@ jobs:
         if: matrix.operating-system == 'ubuntu-18.04'
 
         # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
-        # rsrc will produce *.syso files that should get automatically recognized by go build command and linked into an executable.
-      - name: Embed manifest in win binary
+        # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
+      - name: Download tool to embed manifest in win binary
         run: |
           go get github.com/akavel/rsrc
-          rsrc -arch 386 -manifest manifest.xml
         if: matrix.operating-system == 'windows-2019'
 
         # building the agent for win requires a different task because of an extra flag
@@ -71,7 +70,17 @@ jobs:
         env:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
-        run: task build-win32
+        run: |
+          rsrc -arch 386 -manifest manifest.xml
+          task build-win
+          rm *.syso
+        if: matrix.operating-system == 'windows-2019'
+
+      - name: Build the Agent for win64
+        run: |
+          rsrc -arch amd64 -manifest manifest.xml
+          task build-win
+          rm *.syso
         if: matrix.operating-system == 'windows-2019'
 
       - name: Build the Agent for macos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,13 @@ jobs:
   test-matrix:
     strategy:
       matrix:
-        operating-system: [ubuntu-18.04, windows-2019, windows-2019, macos-10.15]
         include:
+        - operating-system: ubuntu-18.04
         - operating-system: windows-2019
           arch: 386
         - operating-system: windows-2019
           arch: amd64
+        - operating-system: macos-10.15
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,9 @@ jobs:
 
       - name: Build the Agent for macos
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.9 # minimum supported version for mac
+          MACOSX_DEPLOYMENT_TARGET: 10.12 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.12
+          CGO_LDFLAGS: -mmacosx-version-min=10.12
         run: task build
         if: matrix.operating-system == 'macos-10.15'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,11 +76,11 @@ jobs:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: task build-win
-        if: matrix.operating-system == 'windows-2019' || matrix.arch == '386'
+        if: matrix.operating-system == 'windows-2019' && matrix.arch == '386'
 
       - name: Build the Agent for win64
         run: task build-win # GOARCH=amd64 by default on the runners
-        if: matrix.operating-system == 'windows-2019' || matrix.arch == 'amd64'
+        if: matrix.operating-system == 'windows-2019' && matrix.arch == 'amd64'
 
       - name: Build the Agent for macos
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,12 @@ jobs:
         run: task test-unit
 
       - name: Build the Agent for linux
-        run: task build
+        run: task test:build
         if: matrix.operating-system == 'ubuntu-18.04'
 
         # build the agent without GUI support (no tray icon)
       - name: Build the Agent-cli
-        run: task build-cli
+        run: task test:build-cli
         if: matrix.operating-system == 'ubuntu-18.04'
 
         # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
@@ -72,14 +72,14 @@ jobs:
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: |
           rsrc -arch 386 -manifest manifest.xml
-          task build-win
+          task test:build-win
           rm *.syso
         if: matrix.operating-system == 'windows-2019'
 
       - name: Build the Agent for win64
         run: |
           rsrc -arch amd64 -manifest manifest.xml
-          task build-win
+          task test:build-win
           rm *.syso
         if: matrix.operating-system == 'windows-2019'
 
@@ -88,7 +88,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.11 # minimum supported version for mac
           CGO_CFLAGS: -mmacosx-version-min=10.11
           CGO_LDFLAGS: -mmacosx-version-min=10.11
-        run: task build
+        run: task test:build
         if: matrix.operating-system == 'macos-10.15'
 
         # config.ini is required by the executable when it's run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,37 +50,24 @@ jobs:
         run: task test-unit
 
       - name: Build the Agent for linux
-        run: task test:build
+        run: task build
         if: matrix.operating-system == 'ubuntu-18.04'
 
         # build the agent without GUI support (no tray icon)
       - name: Build the Agent-cli
-        run: task test:build-cli
+        run: task build-cli
         if: matrix.operating-system == 'ubuntu-18.04'
-
-        # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
-        # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
-      - name: Download tool to embed manifest in win binary
-        run: |
-          go get github.com/akavel/rsrc
-        if: matrix.operating-system == 'windows-2019'
 
         # building the agent for win requires a different task because of an extra flag
       - name: Build the Agent for win32
         env:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
-        run: |
-          rsrc -arch 386 -manifest manifest.xml
-          task test:build-win
-          rm *.syso
+        run: task build-win
         if: matrix.operating-system == 'windows-2019'
 
       - name: Build the Agent for win64
-        run: |
-          rsrc -arch amd64 -manifest manifest.xml
-          task test:build-win
-          rm *.syso
+        run: task build-win # GOARCH=amd64 by default on the runners
         if: matrix.operating-system == 'windows-2019'
 
       - name: Build the Agent for macos
@@ -88,7 +75,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.11 # minimum supported version for mac
           CGO_CFLAGS: -mmacosx-version-min=10.11
           CGO_LDFLAGS: -mmacosx-version-min=10.11
-        run: task test:build
+        run: task build
         if: matrix.operating-system == 'macos-10.15'
 
         # config.ini is required by the executable when it's run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,12 @@ jobs:
         run: task build-cli
         if: matrix.operating-system == 'ubuntu-18.04'
 
+        # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
+        # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
+      - name: Download tool to embed manifest in win binary
+        run: go get github.com/akavel/rsrc
+        if: matrix.operating-system == 'windows-2019'
+
         # building the agent for win requires a different task because of an extra flag
       - name: Build the Agent for win32
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.14"
 
         # dependencies used for compiling the GUI
       - name: Install Dependencies (Linux)
@@ -85,9 +85,9 @@ jobs:
 
       - name: Build the Agent for macos
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.12 # minimum supported version for mac
-          CGO_CFLAGS: -mmacosx-version-min=10.12
-          CGO_LDFLAGS: -mmacosx-version-min=10.12
+          MACOSX_DEPLOYMENT_TARGET: 10.11 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.11
+          CGO_LDFLAGS: -mmacosx-version-min=10.11
         run: task build
         if: matrix.operating-system == 'macos-10.15'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
         include:
         - operating-system: ubuntu-18.04
         - operating-system: windows-2019
-          arch: 386
+          arch: -386
         - operating-system: windows-2019
-          arch: amd64
+          arch: -amd64
         - operating-system: macos-10.15
 
     runs-on: ${{ matrix.operating-system }}
@@ -76,11 +76,11 @@ jobs:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: task build-win
-        if: matrix.operating-system == 'windows-2019' && matrix.arch == '386'
+        if: matrix.operating-system == 'windows-2019' && matrix.arch == '-386'
 
       - name: Build the Agent for win64
         run: task build-win # GOARCH=amd64 by default on the runners
-        if: matrix.operating-system == 'windows-2019' && matrix.arch == 'amd64'
+        if: matrix.operating-system == 'windows-2019' && matrix.arch == '-amd64'
 
       - name: Build the Agent for macos
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,3 +79,13 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.9 # minimum supported version for mac
         run: task build
         if: matrix.operating-system == 'macos-10.15'
+
+        # config.ini is required by the executable when it's run
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: arduino-create-agent-${{ matrix.operating-system }}
+          path: |
+            arduino-create-agent*
+            config.ini
+          if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,12 @@ jobs:
   test-matrix:
     strategy:
       matrix:
-        operating-system: [ubuntu-18.04, windows-2019, macos-10.15]
+        operating-system: [ubuntu-18.04, windows-2019, windows-2019, macos-10.15]
+        include:
+        - operating-system: windows-2019
+          arch: 386
+        - operating-system: windows-2019
+          arch: amd64
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -70,11 +75,11 @@ jobs:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: task build-win
-        if: matrix.operating-system == 'windows-2019'
+        if: matrix.operating-system == 'windows-2019' || matrix.arch == '386'
 
       - name: Build the Agent for win64
         run: task build-win # GOARCH=amd64 by default on the runners
-        if: matrix.operating-system == 'windows-2019'
+        if: matrix.operating-system == 'windows-2019' || matrix.arch == 'amd64'
 
       - name: Build the Agent for macos
         env:
@@ -88,7 +93,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: arduino-create-agent-${{ matrix.operating-system }}
+          name: arduino-create-agent-${{ matrix.operating-system }}${{ matrix.arch }}
           path: |
             arduino-create-agent*
             config.ini

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Run unit tests
         run: task test-unit
 
-      - name: Build the Agent
+      - name: Build the Agent for linux
         run: task build
-        if: matrix.operating-system != 'windows-2019'
+        if: matrix.operating-system == 'ubuntu-18.04'
 
         # build the agent without GUI support (no tray icon)
       - name: Build the Agent-cli
@@ -73,3 +73,9 @@ jobs:
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: task build-win32
         if: matrix.operating-system == 'windows-2019'
+
+      - name: Build the Agent for macos
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.9 # minimum supported version for mac
+        run: task build
+        if: matrix.operating-system == 'macos-10.15'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,42 +1,35 @@
-version: "2"
+version: '3'
 
 tasks:
 
   build:
-    desc: Build the project
+    desc: Build the project, to use a specific version use `task build TAG_VERSION=x.x.x`
     cmds:
-      - go build -v -i -o {{.APP_NAME}} {{.LDFLAGS}}
+      - go build -v -i {{default "" .ADDITIONAL_FLAGS}} -o {{default "arduino-create-agent" .APP_NAME}} -ldflags '-X main.version={{default .TAG_TEST .TAG_VERSION}} -X main.git_revision={{.COMMIT}} {{default "" .WIN_FLAGS}}'
+    vars:
+      COMMIT:
+        sh: git log -n 1 --format=%h
 
   build-cli:
     desc: Build the project without tray support
     cmds:
-      - go build -v -i -tags cli -o {{.APP_NAME}}_cli {{.LDFLAGS}}
+      - task: build
+        vars:
+          APP_NAME: arduino-create-agent_cli
+          ADDITIONAL_FLAGS: -tags cli
 
   build-win:
-    desc: Build the project for win
+    desc: Build the project for win, to build 32bit `export GOARCH=386` and for 64 bit `export GOARCH=amd64` before `task build-win`
     cmds:
-      - go build -v -i -o {{.APP_NAME}}_{{.GOARCH}} {{.WIN_LDFLAGS}}
-
-  test:build:
-    desc: Build the project for test.yml
-    env:
-    cmds:
-      - go build -v -i -o {{.APP_NAME}} {{.TEST_LDFLAGS}}
-
-  test:build-cli:
-    desc: Build the project without tray support for test.yml
-    cmds:
-      - go build -v -i -tags cli -o {{.APP_NAME}}_cli {{.TEST_LDFLAGS}}
-
-  test:build-win:
-    desc: Build the project for win for test.yml
-    cmds:
-      - go build -v -i -o {{.APP_NAME}}_{{.GOARCH}} {{.TEST_WIN_LDFLAGS}}
-
-  test:
-    desc: Run the full testsuite, `legacy` will be skipped
-    cmds:
-      - task: test-unit
+        # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
+      - go get github.com/akavel/rsrc
+        # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
+      - rsrc -arch {{.GOARCH}} -manifest manifest.xml # GOARCH shoud be either amd64 or 386
+      - task: build
+        vars:
+          APP_NAME: arduino-create-agent_{{.GOARCH}}
+          WIN_FLAGS: -H=windowsgui
+      - rm *.syso # rm file to avoid compilation problems on other platforms
 
   test-unit:
     desc: Run unit tests only
@@ -59,43 +52,16 @@ tasks:
       # - task: python:check
       # - task: docs:check
       # - task: config:check
-
+      
 vars:
+  TAG_TEST: "0.0.0-dev"
+  GOARCH:
+    sh: go env GOARCH
   # all modules of this project except for "gen/..." module
   DEFAULT_TARGETS:
     sh: echo `go list ./... | grep -v 'arduino-create-agent/gen/' | tr '\n' ' '`
-  # build vars
-  APP_NAME: arduino-create-agent
-  GOARCH:
-    sh: go env GOARCH
-  WIN_FLAGS: -H=windowsgui
-  COMMIT:
-    sh: echo ${TRAVIS_COMMIT:-`git log -n 1 --format=%h`}
-  TAG:
-    sh: echo `git describe --tags --abbrev=0`
-  TEST_TAG: "0.0.0-dev"
-  LDFLAGS: >
-    -ldflags '-X main.version={{.TAG}}
-    -X main.git_revision={{.COMMIT}}'
-  WIN_LDFLAGS: >
-    -ldflags '-X main.version={{.TAG}}
-    -X main.git_revision={{.COMMIT}}
-    {{.WIN_FLAGS}}'
-  TEST_LDFLAGS: >
-    -ldflags '-X main.version={{.TEST_TAG}}
-    -X main.git_revision={{.COMMIT}}'
-  TEST_WIN_LDFLAGS: >
-    -ldflags '-X main.version={{.TEST_TAG}}
-    -X main.git_revision={{.COMMIT}}
-    {{.WIN_FLAGS}}'
-
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
   # check-lint vars
   GOLINTBIN:
     sh: go list -f {{"{{"}}".Target{{"}}"}}" golang.org/x/lint/golint
   GOLINTFLAGS: "-min_confidence 0.8 -set_exit_status"
-  # # docs versioning
-  # DOCS_VERSION: dev
-  # DOCS_ALIAS: ""
-  # DOCS_REMOTE: "origin"
-  PRETTIER: prettier@2.0.5

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,17 +5,17 @@ tasks:
   build:
     desc: Build the project
     cmds:
-      - go build -v -i {{.LDFLAGS}}
+      - go build -v -i -o {{.APP_NAME}} {{.LDFLAGS}}
 
   build-cli:
     desc: Build the project without tray support
     cmds:
       - go build -v -i -tags cli -o {{.APP_NAME}}_cli {{.LDFLAGS}}
 
-  build-win32:
-    desc: Build the project for win 32 bit
+  build-win:
+    desc: Build the project for win
     cmds:
-      - go build -v -i {{.WIN_LDFLAGS}}
+      - go build -v -i -o {{.APP_NAME}}_{{.GOARCH}} {{.WIN_LDFLAGS}}
 
   test:
     desc: Run the full testsuite, `legacy` will be skipped
@@ -50,11 +50,15 @@ vars:
     sh: echo `go list ./... | grep -v 'arduino-create-agent/gen/' | tr '\n' ' '`
   # build vars
   APP_NAME: arduino-create-agent
+  GOARCH:
+    sh: go env GOARCH
   WIN_FLAGS: -H=windowsgui
   COMMIT:
     sh: echo ${TRAVIS_COMMIT:-`git log -n 1 --format=%h`}
+  TEST_COMMIT: "deadbeef"
   TAG:
     sh: echo `git describe --tags --abbrev=0`
+  TEST_TAG: "0.0.0-dev"
   LDFLAGS: >
     -ldflags '-X main.version={{.TAG}}
     -X main.git_revision={{.COMMIT}}'
@@ -62,13 +66,14 @@ vars:
     -ldflags '-X main.version={{.TAG}}
     -X main.git_revision={{.COMMIT}}
     {{.WIN_FLAGS}}'
-  # test vars
-  GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
-  TEST_VERSIONSTRING: "0.0.0-alpha"
-  TEST_COMMIT: "deadbeef"
   TEST_LDFLAGS: >
-    -ldflags '-X main.version={{.TEST_VERSIONSTRING}}
+    -ldflags '-X main.version={{.TEST_TAG}}
     -X main.git_revision={{.TEST_COMMIT}}'
+  TEST_TEST_LDFLAGS: >
+    -ldflags '-X main.version={{.TEST_TAG}}
+    -X main.git_revision={{.TEST_COMMIT}}'
+
+  GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
   # check-lint vars
   GOLINTBIN:
     sh: go list -f {{"{{"}}".Target{{"}}"}}" golang.org/x/lint/golint

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,7 +24,7 @@ tasks:
       - rsrc -arch {{.GOARCH}} -manifest manifest.xml # GOARCH shoud be either amd64 or 386
       - task: build
         vars:
-          APP_NAME: arduino-create-agent_{{.GOARCH}}
+          APP_NAME: arduino-create-agent_{{.GOARCH}}.exe
           WIN_FLAGS: -H=windowsgui
       - rm *.syso # rm file to avoid compilation problems on other platforms
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,9 +21,6 @@ tasks:
   build-win:
     desc: Build the project for win, to build 32bit `export GOARCH=386` and for 64 bit `export GOARCH=amd64` before `task build-win`
     cmds:
-        # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
-      - go get github.com/akavel/rsrc
-        # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
       - rsrc -arch {{.GOARCH}} -manifest manifest.xml # GOARCH shoud be either amd64 or 386
       - task: build
         vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,6 +17,22 @@ tasks:
     cmds:
       - go build -v -i -o {{.APP_NAME}}_{{.GOARCH}} {{.WIN_LDFLAGS}}
 
+  test:build:
+    desc: Build the project for test.yml
+    env:
+    cmds:
+      - go build -v -i -o {{.APP_NAME}} {{.TEST_LDFLAGS}}
+
+  test:build-cli:
+    desc: Build the project without tray support for test.yml
+    cmds:
+      - go build -v -i -tags cli -o {{.APP_NAME}}_cli {{.TEST_LDFLAGS}}
+
+  test:build-win:
+    desc: Build the project for win for test.yml
+    cmds:
+      - go build -v -i -o {{.APP_NAME}}_{{.GOARCH}} {{.TEST_WIN_LDFLAGS}}
+
   test:
     desc: Run the full testsuite, `legacy` will be skipped
     cmds:
@@ -55,7 +71,6 @@ vars:
   WIN_FLAGS: -H=windowsgui
   COMMIT:
     sh: echo ${TRAVIS_COMMIT:-`git log -n 1 --format=%h`}
-  TEST_COMMIT: "deadbeef"
   TAG:
     sh: echo `git describe --tags --abbrev=0`
   TEST_TAG: "0.0.0-dev"
@@ -68,10 +83,11 @@ vars:
     {{.WIN_FLAGS}}'
   TEST_LDFLAGS: >
     -ldflags '-X main.version={{.TEST_TAG}}
-    -X main.git_revision={{.TEST_COMMIT}}'
-  TEST_TEST_LDFLAGS: >
+    -X main.git_revision={{.COMMIT}}'
+  TEST_WIN_LDFLAGS: >
     -ldflags '-X main.version={{.TEST_TAG}}
-    -X main.git_revision={{.TEST_COMMIT}}'
+    -X main.git_revision={{.COMMIT}}
+    {{.WIN_FLAGS}}'
 
   GOFLAGS: "-timeout 10m -v -coverpkg=./... -covermode=atomic"
   # check-lint vars

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,7 +24,7 @@ tasks:
       - rsrc -arch {{.GOARCH}} -manifest manifest.xml # GOARCH shoud be either amd64 or 386
       - task: build
         vars:
-          APP_NAME: arduino-create-agent_{{.GOARCH}}.exe
+          APP_NAME: arduino-create-agent.exe
           WIN_FLAGS: -H=windowsgui
       - rm *.syso # rm file to avoid compilation problems on other platforms
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
CI
- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->
Align `test.yml` to `release.yml` and add again upload artifacts: It's really useful to have a reproducible environment to compile the code for every platform.
hardcode gon config for uniformity
Introduce win 64bit build
Change macOS min supported version to 10.11 -> change go version used to build from 1.15 to 10.14 (because of macOS)
Have `test.yml` to push artifact with `0.0.0-dev` in order to block create auto-update  
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
- [X] uniform `test.yml` to `release.yml` https://github.com/arduino/arduino-create-agent/pull/576
- [X] add again upload artifacts to have a place where you can download binaries compiled on various os with the same procedure as the release (https://github.com/arduino/arduino-create-agent/pull/561)
- [X] go version to 1.14
- [X] macOS min version to 10.11
- [x] win 64 bit
