### PR TITLE
Fix naming inconstistencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,7 +383,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: code-sign-mac-installers
     env:
-      PLUGIN_TARGET: "/CreateBridgeStable/"
+      TARGET: "/CreateBridgeStable/"
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -452,5 +452,5 @@ jobs:
           file: release/*
 
       - name: Upload release files on Arduino downloads servers
-        run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.PLUGIN_TARGET }} --include "*"
+        run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }} --include "*"
         if: steps.prerelease.outputs.IS_PRE != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
     env:
       # vars used by installbuilder
       INSTALLBUILDER_PATH: "/opt/installbuilder-20.9.0/bin/builder"
-      # INSTALLER_VARS: "project.outputDirectory=$PWD project.version=${GITHUB_REF##*/} workspace=$PWD realname=Arduino_Create_Bridge"
+      # INSTALLER_VARS: "project.outputDirectory=$PWD project.version=${GITHUB_REF##*/} workspace=$PWD realname=Arduino_Create_Agent"
       # vars passed to installbuilder to install https certs automatically
       CERT_INSTALL: "ask_certificates_install=CI"  # win(edge),mac(safari)
       NO_CERT_INSTALL: "ask_certificates_install=CS"  # linux
@@ -232,7 +232,7 @@ jobs:
 
       - name: Set installer env vars
         run: |
-          echo INSTALLER_VARS="project.outputDirectory=$PWD project.version=${VERSION%.*} workspace=$PWD realname=Arduino_Create_Bridge" >> $GITHUB_ENV
+          echo INSTALLER_VARS="project.outputDirectory=$PWD project.version=${VERSION%.*} workspace=$PWD realname=Arduino_Create_Agent" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -251,11 +251,11 @@ jobs:
         run: chmod -v +x ${{ matrix.executable-path }}arduino-create-agent*
         if: matrix.operating-system == 'ubuntu-18.04' || matrix.operating-system == 'macos-10.15'
 
-      - name: Rename executable to Arduino_Create_Bridge
-        run: mv -v ${{ matrix.executable-path }}arduino-create-agent${{ matrix.extension }} ${{ matrix.executable-path }}Arduino_Create_Bridge${{ matrix.extension }}
+      - name: Rename executable to Arduino_Create_Agent
+        run: mv -v ${{ matrix.executable-path }}arduino-create-agent${{ matrix.extension }} ${{ matrix.executable-path }}Arduino_Create_Agent${{ matrix.extension }}
 
-      - name: Rename executable to Arduino_Create_Bridge_cli
-        run: mv -v ${{ matrix.executable-path }}arduino-create-agent_cli${{ matrix.extension }} ${{ matrix.executable-path }}Arduino_Create_Bridge_cli${{ matrix.extension }}
+      - name: Rename executable to Arduino_Create_Agent_cli
+        run: mv -v ${{ matrix.executable-path }}arduino-create-agent_cli${{ matrix.extension }} ${{ matrix.executable-path }}Arduino_Create_Agent_cli${{ matrix.extension }}
         if: matrix.operating-system == 'ubuntu-18.04'
 
       - name: Save InstallBuilder license to file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
     env:
       # vars used by installbuilder
       INSTALLBUILDER_PATH: "/opt/installbuilder-20.9.0/bin/builder"
-      # INSTALLER_VARS: "project.outputDirectory=$PWD project.version=${GITHUB_REF##*/} workspace=$PWD realname=Arduino_Create_Agent"
+      INSTALLER_VARS: "project.outputDirectory=$PWD project.version=${GITHUB_REF##*/} workspace=$PWD realname=Arduino_Create_Agent"
       # vars passed to installbuilder to install https certs automatically
       CERT_INSTALL: "ask_certificates_install=CI"  # win(edge),mac(safari)
       NO_CERT_INSTALL: "ask_certificates_install=CS"  # linux
@@ -223,17 +223,6 @@ jobs:
       image: floydpink/ubuntu-install-builder:20.9.0
 
     steps:
-
-        # workaround to strip bugfix number from semver (only to make 1.1 release) I will change this in the future
-      - name: Set version env vars
-        # VERSION will be available only in the next step
-        run: |
-          echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
-      - name: Set installer env vars
-        run: |
-          echo INSTALLER_VARS="project.outputDirectory=$PWD project.version=${VERSION%.*} workspace=$PWD realname=Arduino_Create_Agent" >> $GITHUB_ENV
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -273,22 +262,22 @@ jobs:
         # installbuilder reads the env vars with certs paths and use it to sign the installer.
       - name: Launch Bitrock installbuilder-20 with CERT_INSTALL && CHOICE_CERT_INSTALL
         run: |
-          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${INSTALLER_VARS} ${{ env.CERT_INSTALL }}
-          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CI${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-${{matrix.browser}}${{matrix.installer-extension}}
-          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${INSTALLER_VARS} ${{ env.CHOICE_CERT_INSTALL }}
-          cp -vr ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-chrome${{matrix.installer-extension}}
-          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-firefox${{matrix.installer-extension}}
-          rm -r ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-C*
+          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} ${{ env.CERT_INSTALL }}
+          mv -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CI${{matrix.installer-extension}} ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-${{matrix.browser}}${{matrix.installer-extension}}
+          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} ${{ env.CHOICE_CERT_INSTALL }}
+          cp -vr ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-chrome${{matrix.installer-extension}}
+          mv -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CC${{matrix.installer-extension}} ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}${{ matrix.arch }}-installer-firefox${{matrix.installer-extension}}
+          rm -r ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-C*
         if: matrix.operating-system == 'windows-2019' || matrix.operating-system == 'macos-10.15'
 
         # linux
       - name: Launch Bitrock installbuilder-20 with NO_CERT_INSTALL
         run: |
-          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${INSTALLER_VARS} ${{ env.NO_CERT_INSTALL }}
-          cp -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CS.run ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-chrome.run
-          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CS.run ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-firefox.run
-          cp -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CS.tar.gz ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-chrome.tar.gz
-          mv -v ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-CS.tar.gz ArduinoCreateAgent-${VERSION%.*}-${{ matrix.install-builder-name }}-installer-firefox.tar.gz
+          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.install-builder-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} ${{ env.NO_CERT_INSTALL }}
+          cp -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CS.run ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-chrome.run
+          mv -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CS.run ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-firefox.run
+          cp -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CS.tar.gz ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-chrome.tar.gz
+          mv -v ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-CS.tar.gz ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.install-builder-name }}-installer-firefox.tar.gz
         if: matrix.operating-system == 'ubuntu-18.04'
 
       - name: Upload artifacts
@@ -308,22 +297,15 @@ jobs:
         browser: [safari, firefox, chrome]
 
     steps:
-
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
           name: ArduinoCreateAgent-osx
           path: ArduinoCreateAgent-osx
 
-        # workaround to strip bugfix number from semver (only to make 1.1 release) I will change this in the future
-      - name: Set version env vars
-        # VERSION will be available only in the next step
-        run: |
-          echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
         # zip artifacts do not mantain executable permission
       - name: Make executable
-        run: chmod -v +x ArduinoCreateAgent-osx/ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.app/Contents/MacOS/*
+        run: chmod -v +x ArduinoCreateAgent-osx/ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.app/Contents/MacOS/*
 
       - name: Import Code-Signing Certificates
         env:
@@ -346,7 +328,7 @@ jobs:
         # gon does not allow env variables in config file (https://github.com/mitchellh/gon/issues/20)
         run: |
           cat > gon.config_installer.hcl <<EOF
-          source = ["ArduinoCreateAgent-osx/ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.app"]
+          source = ["ArduinoCreateAgent-osx/ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.app"]
           bundle_id = "cc.arduino.arduino-agent-installer"
 
           sign {
@@ -354,7 +336,7 @@ jobs:
           }
 
           dmg {
-            output_path = "ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.dmg"
+            output_path = "ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.dmg"
             volume_name = "ArduinoCreateAgent"
           }
           EOF
@@ -364,13 +346,13 @@ jobs:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         run: |
-          echo "gon will notarize executable in ArduinoCreateAgent-osx/ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.app"
+          echo "gon will notarize executable in ArduinoCreateAgent-osx/ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.app"
           gon -log-level=debug -log-json gon.config_installer.hcl
         timeout-minutes: 30
 
       #  tar dmg file to keep executable permission
       - name: Tar files to keep permissions
-        run: tar -cvf ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.tar ArduinoCreateAgent-${VERSION%.*}-osx-installer-${{ matrix.browser }}.dmg
+        run: tar -cvf ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.tar ArduinoCreateAgent-${GITHUB_REF##*/}-osx-installer-${{ matrix.browser }}.dmg
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -388,7 +370,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:
-
       - name: Download artifact
         uses: actions/download-artifact@v2 # download all the artifacts
 

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -48,9 +48,9 @@ func (s *Systray) start() {
 	s.updateMenuItem(mRmCrashes, s.CrashesIsEmpty())
 
 	// Add pause/quit
-	mPause := systray.AddMenuItem("Pause Plugin", "")
+	mPause := systray.AddMenuItem("Pause Agent", "")
 	systray.AddSeparator()
-	mQuit := systray.AddMenuItem("Quit Plugin", "")
+	mQuit := systray.AddMenuItem("Quit Agent", "")
 
 	// Add configs
 	s.addConfigs()
@@ -116,9 +116,9 @@ func (s *Systray) RemoveCrashes() {
 func (s *Systray) startHibernate() {
 	systray.SetIcon(icon.GetIconHiber())
 
-	mResume := systray.AddMenuItem("Resume Plugin", "")
+	mResume := systray.AddMenuItem("Resume Agent", "")
 	systray.AddSeparator()
-	mQuit := systray.AddMenuItem("Quit Plugin", "")
+	mQuit := systray.AddMenuItem("Quit Agent", "")
 
 	// listen for events
 	go func() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
rename
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Sometimes we refer to the agent with the wrong nomenclature (e.g. Pluging or Bridge) 
* **What is the new behavior?**
<!-- if this is a feature change -->
Rename Plugin or Bridge to Agent
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
Yes
* **Other information**:
<!-- Any additional information that could help the review process -->
- [X] Rename "Plugin" to "Agent"
- [X] Rename "Bridge" to "Agent"
- [X] Rename "Bridge" to "Agent" also in https://github.com/bcmi-labs/arduino-create-agent-installer/pull/13