### PR TITLE
Fix temp binary not starting correclty

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,9 +146,8 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		Systray.Start()
 	}
-
-	Systray.Start()
 }
 
 func copyExe(from, to string) error {

--- a/main.go
+++ b/main.go
@@ -132,12 +132,13 @@ func main() {
 
 	// If the executable is temporary, copy it to the full path, then restart
 	if strings.Contains(path, "-temp") {
-		err := copyExe(path, updater.BinPath(path))
+		newPath := updater.BinPath(path)
+		err := copyExe(path, newPath)
 		if err != nil {
 			panic(err)
 		}
 
-		Systray.Restart()
+		Systray.Update(newPath)
 	} else {
 		// Otherwise copy to a path with -temp suffix
 		err := copyExe(path, updater.TempPath(path))

--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func main() {
 		newPath := updater.BinPath(path)
 		err := copyExe(path, newPath)
 		if err != nil {
+			log.Println("Copy error: ", err)
 			panic(err)
 		}
 
@@ -153,10 +154,12 @@ func main() {
 func copyExe(from, to string) error {
 	data, err := ioutil.ReadFile(from)
 	if err != nil {
+		log.Println("Cannot read file: ", from)
 		return err
 	}
 	err = ioutil.WriteFile(to, data, 0755)
 	if err != nil {
+		log.Println("Cannot write file: ", to)
 		return err
 	}
 	return nil

--- a/systray/systray.go
+++ b/systray/systray.go
@@ -26,14 +26,15 @@ type Systray struct {
 // it works by finding the executable path and launching it before quitting
 func (s *Systray) Restart() {
 
-	fmt.Println(s.path)
-	fmt.Println(osext.Executable())
 	if s.path == "" {
+		fmt.Println("Update binary path not set")
 		var err error
 		s.path, err = osext.Executable()
 		if err != nil {
 			fmt.Printf("Error getting exe path using osext lib. err: %v\n", err)
 		}
+	} else {
+		fmt.Println("Starting updated binary: ", s.path)
 	}
 
 	// Trim newlines (needed on osx)

--- a/systray/systray.go
+++ b/systray/systray.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/kardianos/osext"
 )
 
@@ -27,14 +29,14 @@ type Systray struct {
 func (s *Systray) Restart() {
 
 	if s.path == "" {
-		fmt.Println("Update binary path not set")
+		log.Println("Update binary path not set")
 		var err error
 		s.path, err = osext.Executable()
 		if err != nil {
-			fmt.Printf("Error getting exe path using osext lib. err: %v\n", err)
+			log.Printf("Error getting exe path using osext lib. err: %v\n", err)
 		}
 	} else {
-		fmt.Println("Starting updated binary: ", s.path)
+		log.Println("Starting updated binary: ", s.path)
 	}
 
 	// Trim newlines (needed on osx)
@@ -51,7 +53,7 @@ func (s *Systray) Restart() {
 	cmd := exec.Command(s.path, args...)
 	err := cmd.Start()
 	if err != nil {
-		fmt.Printf("Error restarting process: %v\n", err)
+		log.Printf("Error restarting process: %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Fixes a regression introduced in #551 (https://github.com/arduino/arduino-create-agent/pull/551/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R139)
When the binary file ending with `-temp` is manually started it does not start the correct bin file but it keeps starting itself. 
* **What is the new behavior?**
<!-- if this is a feature change -->
Fixed. Now when the temp binary is started it correctly copy itself to the full binary (binary file not ending with `-temp`) and starts it
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
