### PR TITLE
[EDITOR-512] Fix concurrent map read and map write

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,7 +10,8 @@
 ```go
 type Tools struct {
 	Directory string
-	IndexURL  string
+    IndexURL  string
+    LastRefresh time.Time
 	Logger    log.StdLogger
 }
 ```
@@ -20,6 +21,7 @@ to download a tool from the arduino servers.
 
 - *Directory* contains the location where the tools are downloaded.
 - *IndexURL* contains the url where the tools description is contained.
+- *LastRefresh* contains the last update time
 - *Logger* is a StdLogger used for reporting debug and info messages
 - *installed* contains a map of the tools and their exact location
 

--- a/tools/download.go
+++ b/tools/download.go
@@ -193,10 +193,14 @@ func (t *Tools) Download(pack, name, version, behaviour string) error {
 
 	// Check if it already exists
 	if behaviour == "keep" {
+		t.mutex.RLock()
 		location, ok := t.installed[key]
+		t.mutex.RUnlock()
 		if ok && pathExists(location) {
 			// overwrite the default tool with this one
+			t.mutex.Lock()
 			t.installed[correctTool.Name] = location
+			t.mutex.Unlock()
 			t.Logger("The tool is already present on the system")
 			return t.writeMap()
 		}
@@ -267,8 +271,10 @@ func (t *Tools) Download(pack, name, version, behaviour string) error {
 	// Update the tool map
 	t.Logger("Updating map with location " + location)
 
+	t.mutex.Lock()
 	t.installed[name] = location
 	t.installed[name+"-"+correctTool.Version] = location
+	t.mutex.Unlock()
 	return t.writeMap()
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Sometimes the agent randomly crashes with `fatal error: concurrent map read and map write`
The crashreport contains something like:

```
fatal error: concurrent map read and map write

goroutine 2178 [running]:
runtime.throw(0xd4c202, 0x21)
	/opt/hostedtoolcache/go/1.14.12/x64/src/runtime/panic.go:1116 +0x72 fp=0xc0007e7680 sp=0xc0007e7650 pc=0x4372f2
runtime.mapaccess2(0xc3f740, 0xc0001106c0, 0xc0004f40a0, 0xc0004f40a0, 0xc000630902)
	/opt/hostedtoolcache/go/1.14.12/x64/src/runtime/map.go:469 +0x258 fp=0xc0007e76c0 sp=0xc0007e7680 pc=0x411908
reflect.mapaccess(0xc3f740, 0xc0001106c0, 0xc0004f40a0, 0xd42538)
	/opt/hostedtoolcache/go/1.14.12/x64/src/runtime/map.go:1309 +0x3f fp=0xc0007e76f8 sp=0xc0007e76c0 pc=0x413b1f
reflect.Value.MapIndex(0xc3f740, 0xc0001106c0, 0x15, 0xc02c20, 0xc0004f40a0, 0x98, 0xd204e0, 0xc3f740, 0xc3f740)
	/opt/hostedtoolcache/go/1.14.12/x64/src/reflect/value.go:1173 +0x16d fp=0xc0007e7770 sp=0xc0007e76f8 pc=0x4986fd
encoding/json.mapEncoder.encode(0xd720b0, 0xc00049e400, 0xc3f740, 0xc0001106c0, 0x15, 0xc30100)
	/opt/hostedtoolcache/go/1.14.12/x64/src/encoding/json/encode.go:801 +0x305 fp=0xc0007e78e8 sp=0xc0007e7770 pc=0x517715
encoding/json.mapEncoder.encode-fm(0xc00049e400, 0xc3f740, 0xc0001106c0, 0x15, 0x1610100)
	/opt/hostedtoolcache/go/1.14.12/x64/src/encoding/json/encode.go:777 +0x64 fp=0xc0007e7928 sp=0xc0007e78e8 pc=0x5235e4
encoding/json.(*encodeState).reflectValue(0xc00049e400, 0xc3f740, 0xc0001106c0, 0x15, 0xc0007e0100)
	/opt/hostedtoolcache/go/1.14.12/x64/src/encoding/json/encode.go:358 +0x82 fp=0xc0007e7960 sp=0xc0007e7928 pc=0x514892
encoding/json.(*encodeState).marshal(0xc00049e400, 0xc3f740, 0xc0001106c0, 0x510100, 0x0, 0x0)
	/opt/hostedtoolcache/go/1.14.12/x64/src/encoding/json/encode.go:330 +0xf0 fp=0xc0007e79c0 sp=0xc0007e7960 pc=0x5143b0
encoding/json.Marshal(0xc3f740, 0xc0001106c0, 0xc0007e7ab0, 0xb8d4a1, 0xc000380a20, 0xc0007e7a98, 0xc0001bb400)
	/opt/hostedtoolcache/go/1.14.12/x64/src/encoding/json/encode.go:161 +0x52 fp=0xc0007e7a38 sp=0xc0007e79c0 pc=0x513732
github.com/arduino/arduino-create-agent/tools.(*Tools).writeMap(0x1616ae0, 0x29, 0xc00043cbc6)
	/home/runner/work/arduino-create-agent/arduino-create-agent/tools/tools.go:90 +0x42 fp=0xc0007e7ac0 sp=0xc0007e7a38 pc=0xb1f8e2
github.com/arduino/arduino-create-agent/tools.(*Tools).Download(0x1616ae0, 0xc0002eca6a, 0x7, 0xc0002eca5d, 0x6, 0xc0002eca64, 0x5, 0xc0002eca72, 0x4, 0x0, ...)
	/home/runner/work/arduino-create-agent/arduino-create-agent/tools/download.go:201 +0x13a3 fp=0xc0007e7ef8 sp=0xc0007e7ac0 pc=0xb1c123
main.checkCmd.func2(0xc0002eca50, 0x26)
	/home/runner/work/arduino-create-agent/arduino-create-agent/hub.go:194 +0x11c fp=0xc0007e7fd0 sp=0xc0007e7ef8 pc=0xb8ccac
runtime.goexit()
	/opt/hostedtoolcache/go/1.14.12/x64/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc0007e7fd8 sp=0xc0007e7fd0 pc=0x466f41
created by main.checkCmd
	/home/runner/work/arduino-create-agent/arduino-create-agent/hub.go:165 +0x623

```

* **What is the new behavior?**
<!-- if this is a feature change -->
This behavior should be fixed

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
In the process of fixing the bug I also updated the tools documentation
