### PR TITLE
[EDITOR-607] add workflow to close stale issues (labeled with waiting for feedback)

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -13,6 +13,6 @@ jobs:
           close-issue-message: 'This issue has been closed becasue has been stale for 7 days. If you think this issue deserves some attention feel free to reopen it'
           days-before-stale: 14
           days-before-close: 7
-          days-before-pr-close: -1 // never close PR
-          only-labels: waiting for feedback // only issues marked with this label will be affected
+          days-before-pr-close: -1
+          only-labels: 'waiting for feedback'
           debug-only: true

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,6 +1,7 @@
 name: Close stale issues
 on:
-  workflow_dispatch
+  schedule:
+    - cron:  '*/15 * * * *'
 
 jobs:
   stale:

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,7 +1,7 @@
 name: Close stale issues
 on:
   schedule:
-    - cron:  '*/15 * * * *'
+    - cron:  '30 8 * * mon'
 
 jobs:
   stale:
@@ -15,4 +15,4 @@ jobs:
           days-before-close: 7
           days-before-pr-close: -1
           only-labels: 'waiting for feedback'
-          debug-only: true
+          debug-only: false

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,17 @@
+name: Close stale issues
+on:
+  workflow_dispatch
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: 'This issue has been marked as stale because it has been open 14 days with no activity. Remove stale label or comment, otherwise it will be closed in 7 days '
+          close-issue-message: 'This issue has been closed becasue has been stale for 7 days. If you think this issue deserves some attention feel free to reopen it'
+          days-before-stale: 14
+          days-before-close: 7
+          days-before-pr-close: -1 // never close PR
+          only-labels: waiting for feedback // only issues marked with this label will be affected
+          debug-only: true

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,7 +1,6 @@
 name: Close stale issues
 on:
-  schedule:
-    - cron:  '*/15 * * * *'
+  workflow_dispatch
 
 jobs:
   stale:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [x] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
CI
- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->
Issues older than 14 days (labeled with **waiting for feedback**) will be marked as stale if they are inactive for 14 days and then closed after another 7 days
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->

* **Other information**:
<!-- Any additional information that could help the review process -->
