### PR TITLE
[EDITOR-621] add port to serial output

### DIFF
--- a/bufferflow_timed.go
+++ b/bufferflow_timed.go
@@ -18,12 +18,13 @@ type BufferflowTimed struct {
 
 var (
 	bufferedOutput string
+	sPort string
 )
 
 func (b *BufferflowTimed) Init() {
 	log.Println("Initting timed buffer flow (output once every 16ms)")
 	bufferedOutput = ""
-	port = ""
+	sPort = ""
 
 	go func() {
 		b.ticker = time.NewTicker(16 * time.Millisecond)
@@ -33,16 +34,16 @@ func (b *BufferflowTimed) Init() {
 			select {
 			case data := <-b.Input:
 				bufferedOutput = bufferedOutput + data
-				port = b.Port
+				sPort = b.Port
 			case <-b.ticker.C:
 				if bufferedOutput != "" {
-					m := SpPortMessage{port, bufferedOutput}
+					m := SpPortMessage{sPort, bufferedOutput}
 					buf, _ := json.Marshal(m)
 					// data is now encoded in base64 format
 					// need a decoder on the other side
 					b.Output <- []byte(buf)
 					bufferedOutput = ""
-					port = ""
+					sPort = ""
 				}
 			case <-b.done:
 				break Loop

--- a/bufferflow_timed.go
+++ b/bufferflow_timed.go
@@ -23,6 +23,7 @@ var (
 func (b *BufferflowTimed) Init() {
 	log.Println("Initting timed buffer flow (output once every 16ms)")
 	bufferedOutput = ""
+	port = ""
 
 	go func() {
 		b.ticker = time.NewTicker(16 * time.Millisecond)
@@ -32,14 +33,16 @@ func (b *BufferflowTimed) Init() {
 			select {
 			case data := <-b.Input:
 				bufferedOutput = bufferedOutput + data
+				port = b.Port
 			case <-b.ticker.C:
 				if bufferedOutput != "" {
-					m := SpPortMessage{b.Port, bufferedOutput}
+					m := SpPortMessage{port, bufferedOutput}
 					buf, _ := json.Marshal(m)
 					// data is now encoded in base64 format
 					// need a decoder on the other side
 					b.Output <- []byte(buf)
 					bufferedOutput = ""
+					port = ""
 				}
 			case <-b.done:
 				break Loop

--- a/bufferflow_timed.go
+++ b/bufferflow_timed.go
@@ -34,7 +34,7 @@ func (b *BufferflowTimed) Init() {
 				bufferedOutput = bufferedOutput + data
 			case <-b.ticker.C:
 				if bufferedOutput != "" {
-					m := SpPortMessage{bufferedOutput}
+					m := SpPortMessage{b.Port, bufferedOutput}
 					buf, _ := json.Marshal(m)
 					// data is now encoded in base64 format
 					// need a decoder on the other side

--- a/bufferflow_timedraw.go
+++ b/bufferflow_timedraw.go
@@ -32,7 +32,7 @@ func (b *BufferflowTimedRaw) Init() {
 		b.ticker = time.NewTicker(16 * time.Millisecond)
 		for _ = range b.ticker.C {
 			if len(bufferedOutputRaw) != 0 {
-				m := SpPortMessageRaw{bufferedOutputRaw}
+				m := SpPortMessageRaw{b.Port, bufferedOutputRaw}
 				buf, _ := json.Marshal(m)
 				// data is now encoded in base64 format
 				// need a decoder on the other side

--- a/serialport.go
+++ b/serialport.go
@@ -83,12 +83,12 @@ type qwReport struct {
 }
 
 type SpPortMessage struct {
-	// P string // the port, i.e. com22
+	P string // the port, i.e. com22
 	D string // the data, i.e. G0 X0 Y0
 }
 
 type SpPortMessageRaw struct {
-	// P string // the port, i.e. com22
+	P string // the port, i.e. com22
 	D []byte // the data, i.e. G0 X0 Y0
 }
 
@@ -157,7 +157,7 @@ func (p *serport) reader() {
 
 			if p.bufferwatcher.IsBufferGloballySendingBackIncomingData() == false {
 				//m := SpPortMessage{"Alice", "Hello"}
-				m := SpPortMessage{data}
+				m := SpPortMessage{p.portConf.Name, data}
 				//log.Print("The m obj struct is:")
 				//log.Print(m)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
feature

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently we only get a serial object formatted like this `{"D":"output text here\r\n"}`
* **What is the new behavior?**
<!-- if this is a feature change -->
The output now includes the port generating the output: 
```
{
    "P": "dev/ttyACM0",
    "D":"output text here\r\n"
}
```
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
Probably not
* **Other information**:
<!-- Any additional information that could help the review process -->
