### PR TITLE
use stricter mutex policy to prevent installed.json corruption

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -113,13 +113,13 @@ func (t *Tools) writeMap() error {
 
 // readMap() reads the installed map from json file "installed.json"
 func (t *Tools) readMap() error {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
 	filePath := path.Join(dir(), "installed.json")
 	b, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
 	return json.Unmarshal(b, &t.installed)
 }
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -101,9 +101,9 @@ func (t *Tools) GetLocation(command string) (string, error) {
 
 // writeMap() writes installed map to the json file "installed.json"
 func (t *Tools) writeMap() error {
-	t.mutex.RLock()
+	t.mutex.Lock()
 	b, err := json.Marshal(t.installed)
-	t.mutex.RUnlock()
+	defer t.mutex.Unlock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Bug fix, followup of #585 
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Sometimes the agent responds with a 500 error to `curl ‘http://127.0.0.1:8991/v2/pkgs/tools/installed’` with this payload `{“name”:“fault”,“id”:“JOhq4y8g”,“message”:“invalid character ‘s’ after top-level value”,“temporary”:false,“timeout”:false,“fault”:true}`.
This error should be caused by a race condition with the result that `installed.json` file gets corrupted
* **What is the new behavior?**
<!-- if this is a feature change -->
This PR should fix this behavior by adding a stricter mutex policy and releasing the mutex only after the file has been written
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
