### PR TITLE
[skip-changelog] fix create-changelog action failing because it could not find a git repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -440,6 +440,11 @@ jobs:
     needs: code-sign-mac-installers
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch all history for the create changelog step to work properly
+
       - name: Download artifact
         uses: actions/download-artifact@v2 # download all the artifacts
 


### PR DESCRIPTION
fix bug introduced in #639

**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The workflow is not working correctly
* **What is the new behavior?**
<!-- if this is a feature change -->

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
Nop
* **Other information**:
<!-- Any additional information that could help the review process -->
