### PR TITLE
Add CI workflow to publish tester builds

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -12,6 +12,9 @@ on:
       - "Taskfile.ya?ml"
       - "DistTasks.ya?ml"
       - "**.go"
+      - "icon/**"
+      - "config.ini"
+      - "manifest.xml"
   pull_request:
     paths:
       - ".github/workflows/publish-go-tester-task.ya?ml"
@@ -20,6 +23,9 @@ on:
       - "Taskfile.ya?ml"
       - "DistTasks.ya?ml"
       - "**.go"
+      - "icon/**"
+      - "config.ini"
+      - "manifest.xml"
   workflow_dispatch:
   repository_dispatch:
 
@@ -58,15 +64,11 @@ jobs:
     #use the strategy instead because we still use the native build
     strategy:
       matrix:
-        os:
-          os: [ubuntu-18.04, windows-2019, macos-10.15]
-          arch: [-amd64]
-          include:
-          - os: windows-2019
-            arch: -386
-            ext: ".exe"
-          - os: windows-2019
-            ext: ".exe"
+        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        arch: [-amd64]
+        include:
+        - os: windows-2019
+          arch: -386
 
     defaults:
       run:
@@ -94,7 +96,7 @@ jobs:
       # dependencies used for compiling the GUI
       - name: Install Dependencies (Linux)
         run: sudo apt update && sudo apt install -y --no-install-recommends build-essential libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev
-        if: matrix.os == 'ubuntu-18.04'
+        if: runner.os == 'Linux'
 
       - name: Install Task
         uses: arduino/setup-task@v1
@@ -104,18 +106,18 @@ jobs:
 
       - name: Build the Agent for linux
         run: task go:build
-        if: matrix.os == 'ubuntu-18.04'
+        if: runner.os == 'Linux'
 
         # build the agent without GUI support (no tray icon)
       - name: Build the Agent-cli
         run: task go:build-cli
-        if: matrix.os == 'ubuntu-18.04'
+        if: runner.os == 'Linux'
 
         # the manifest is required by windows GUI apps, otherwise the binary will crash with: "Unable to create main window: TTM_ADDTOOL failed" (for reference https://github.com/lxn/walk/issues/28)
         # rsrc will produce a *.syso file that should get automatically recognized by go build command and linked into an executable.
       - name: Download tool to embed manifest in win binary
         run: go get github.com/akavel/rsrc
-        if: matrix.os == 'windows-2019'
+        if: runner.os == 'Windows'
 
         # building the agent for win requires a different task because of an extra flag
       - name: Build the Agent for win32
@@ -123,11 +125,11 @@ jobs:
           GOARCH: 386  # 32bit architecture (for support)
           GO386: 387  # support old instruction sets without MMX (used in the Pentium 4) (will be deprecated in GO > 1.15 https://golang.org/doc/go1.15)
         run: task go:build-win
-        if: matrix.os == 'windows-2019' && matrix.arch == '-386'
+        if: runner.os == 'Windows' && matrix.arch == '-386'
 
       - name: Build the Agent for win64
         run: task go:build-win # GOARCH=amd64 by default on the runners
-        if: matrix.os == 'windows-2019' && matrix.arch == '-amd64'
+        if: runner.os == 'Windows' && matrix.arch == '-amd64'
 
       - name: Build the Agent for macos
         env:
@@ -135,7 +137,7 @@ jobs:
           CGO_CFLAGS: -mmacosx-version-min=10.11
           CGO_LDFLAGS: -mmacosx-version-min=10.11
         run: task go:build
-        if: matrix.os == 'macos-10.15'       
+        if: runner.os == 'macOS'
 
       # config.ini is required by the executable when it's run
       - name: Upload artifacts


### PR DESCRIPTION
On every commit to a pull request or the repository:

- Build the project for all supported platforms.
- Upload the builds as workflow artifacts.

This makes it possible for any interested party to participate in beta testing without setting up a build system locally.