### PR TITLE
Pin task version to 3.9.0 because of the PATH on win bug

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -102,7 +102,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Build the Agent for linux
         run: task go:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Taskfile
         uses: arduino/setup-task@v1
         with:
-          version: '3.x'
+          version: 3.9.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check the code is good

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -91,7 +91,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
         # build the agent without GUI support (no tray icon) for integration testing
       - name: Build the Agent-cli

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -89,7 +89,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
         # https://github.com/getlantern/systray#linux
       - name: Install Dependencies (Linux)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Infrastructure fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The **Test Go** workflow on Windows is broken after the newest release of Task (3.9.1) and was working fine with 3.9.0
The problem should be linked to the upgrade in `mvdan/sh` they did in 3.9.1.
The bug is present only on Windows, apparently the PATH env variable is not expanded correctly under subcommands.
* **What is the new behavior?**
<!-- if this is a feature change -->
To mitigate the issue, we decided to pin the task version used to 3.9.0 in the workflows
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
