### PR TITLE
Correct key name in "Close stale issues" workflow

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron:  '30 8 * * mon'
 
-permission:
+permissions:
   issues: write
 
 jobs:


### PR DESCRIPTION
The previous incorrect key name `permission` caused the workflow run to error:

https://github.com/per1234/arduino-create-agent/actions/runs/1525440740

```
Invalid workflow file : .github/workflows/close-stale-issues.yml#L7
The workflow is not valid. .github/workflows/close-stale-issues.yml (Line: 7, Col: 1): Unexpected value 'permission'
```

The correct key name is `permissions`:

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions
