### PR TITLE
[skip-changelog] Revert "Pin task version in workflows running on windows (#677)"

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -102,7 +102,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
       - name: Build the Agent for linux
         run: task go:build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install Taskfile
         uses: arduino/setup-task@v1
         with:
-          version: 3.9.0
+          version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check the code is good

--- a/.github/workflows/test-go-integration-task.yml
+++ b/.github/workflows/test-go-integration-task.yml
@@ -91,7 +91,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
         # build the agent without GUI support (no tray icon) for integration testing
       - name: Build the Agent-cli

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -89,7 +89,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.9.0
+          version: 3.x
 
         # https://github.com/getlantern/systray#linux
       - name: Install Dependencies (Linux)


### PR DESCRIPTION
This reverts commit 320f7de334005f309fd8487ec3b3c11d235ba191.

**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
infrastructure update
- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->
https://github.com/arduino/tooling-project-assets/pull/186
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
nop
* **Other information**:
<!-- Any additional information that could help the review process -->
