### PR TITLE
fix `go vet` failing, followup of #668

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -114,11 +114,11 @@ func spList(network bool) {
 	var err error
 	if network {
 		NetworkPorts.mu.Lock()
-		ls, err = json.MarshalIndent(NetworkPorts, "", "\t")
+		ls, err = json.MarshalIndent(&NetworkPorts, "", "\t")
 		NetworkPorts.mu.Unlock()
 	} else {
 		SerialPorts.mu.Lock()
-		ls, err = json.MarshalIndent(SerialPorts, "", "\t")
+		ls, err = json.MarshalIndent(&SerialPorts, "", "\t")
 		SerialPorts.mu.Unlock()
 	}
 	if err != nil {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The release workflow was failing when running `go vet` with:
```
./serial.go:117:32: call of json.MarshalIndent copies lock value: github.com/arduino/arduino-create-agent.SpPortList contains sync.Mutex
./serial.go:121:32: call of json.MarshalIndent copies lock value: github.com/arduino/arduino-create-agent.SpPortList contains sync.Mutex
```
* **What is the new behavior?**
<!-- if this is a feature change -->
fixed
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
nop
* **Other information**:
<!-- Any additional information that could help the review process -->
