### PR TITLE
Remove `notes` field from label configuration file

### DIFF
--- a/.github/label-configuration-files/labels.yml
+++ b/.github/label-configuration-files/labels.yml
@@ -1,13 +1,11 @@
 # Used by the "Sync Labels" workflow
 # See: https://github.com/Financial-Times/github-label-sync#label-config-file
 
+# Added by the "Close stale issues" workflow.
 - name: "conclusion: stale"
   color: "940404"
   description: Closed due to lack of activity
-  notes: |
-    Added by the "Close stale issues" workflow.
+# Added by the "Close stale issues" workflow.
 - name: "status: stale"
   color: "940404"
   description: Pending closure due to lack of activity
-  notes: |
-    Added by the "Close stale issues" workflow.


### PR DESCRIPTION
At the time the reference configuration file was developed, it was in JSON, which does not support comments. I found the need to add some internal explanatory commentary to some of the labels, so I added an arbitrary `notes` key as a container for this information, and our JSON schema was also configured to accept this field.

I later decided to convert the files to YAML, since that is the language used by the majority of the asset configuration files. At this point it became possible to use comments, but the `notes` field was already in place so it seemed pointless to change it.

Validation of the configuration file [was added](https://github.com/Financial-Times/github-label-sync/pull/158) to the "**GitHub Label Sync**" tool in [the recent 2.1.0 release](https://github.com/Financial-Times/github-label-sync/releases/tag/v2.1.0). Before 2.1.0, the tool ignored any additional properties in the label configuration objects. It now errors if there are any unexpected properties.

This `notes` field now causes the label configuration files that contain it to be considered invalid by the tool, and by our custom JSON schema:

https://github.com/arduino/arduino-create-agent/runs/5767351577?check_suite_focus=true#step:5:72

```text
.github/label-configuration-files/labels.yml invalid
[
  {
    instancePath: '/0',
    schemaPath: '#/items/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'notes' },
    message: 'must NOT have additional properties'
  },
  {
    instancePath: '/1',
    schemaPath: '#/items/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'notes' },
    message: 'must NOT have additional properties'
  }
]
```

So the `notes` field is hereby removed, with the contents moved to comments.
