### PR TITLE
General enhancements to macOS ventura binary

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -132,9 +132,9 @@ jobs:
 
       - name: Build the Agent for macos
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.11 # minimum supported version for mac
-          CGO_CFLAGS: -mmacosx-version-min=10.11
-          CGO_LDFLAGS: -mmacosx-version-min=10.11
+          MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.15
+          CGO_LDFLAGS: -mmacosx-version-min=10.15
         run: task go:build
         if: runner.os == 'macOS'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: arduino-create-agent
-  TARGET: "/CreateAgent/Stable"
+  TARGET: "/CreateAgent/Stable/"
   OLD_TARGET: "/CreateBridge/" # compatibility with older releases (we can't change config.ini)
   VERSION_TARGET: "arduino-create-static/agent-metadata/"
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -26,6 +26,8 @@ env:
 jobs:
   # The build job is responsible for: configuring the environment, testing and compiling process
   build:
+    outputs:
+      prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-12]
@@ -204,13 +206,13 @@ jobs:
           name: ArduinoCreateAgent.app
           path: ArduinoCreateAgent.app.tar
           
-  # The notarize-macos job will download the macos bundle from the previous job, sign, notarize and re-upload it.
+  # The notarize-macos job will download the macos bundle from the previous job, sign, notarize and re-upload it, uploading it also on s3 download servers for the autoupdate.
   notarize-macos:
     name: Notarize bundle
     runs-on: macos-12
     env:
       GON_PATH: ${{ github.workspace }}/gon
-    needs: create-macos-bundle
+    needs: [build, create-macos-bundle]
 
     steps:
       - name: Download artifact
@@ -276,6 +278,10 @@ jobs:
 
       - name: Sign and notarize binary
         run: gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
+        
+      - name: Upload autoupdate bundle to Arduino downloads servers
+        run: aws s3 cp ArduinoCreateAgent.app_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}${GITHUB_REF/refs\/tags\//}/ # the version should be created in th the build job
+        if: ${{ needs.build.outputs.prerelease != 'true' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -493,7 +499,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-20.04
-    needs: code-sign-mac-installers
+    needs: [build, code-sign-mac-installers]
 
     steps:
       - name: Checkout
@@ -503,14 +509,6 @@ jobs:
 
       - name: Download artifact
         uses: actions/download-artifact@v3 # download all the artifacts
-
-      - name: Identify Prerelease
-        # This is a workaround while waiting for create-release action to implement auto pre-release based on tag
-        id: prerelease
-        run: |
-          curl -L -s https://github.com/fsaintjacques/semver-tool/archive/3.1.0.zip -o /tmp/3.1.0.zip
-          unzip -p /tmp/3.1.0.zip semver-tool-3.1.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ $(/tmp/semver get prerel ${GITHUB_REF/refs\/tags\//}) ]]; then echo "IS_PRE=true" >> $GITHUB_OUTPUT; fi
 
       #  mandatory step because upload-release-action does not support multiple folders
       - name: prepare artifacts for the release
@@ -562,7 +560,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: ${{ steps.release_body.outputs.RBODY}}
           draft: false
-          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+          prerelease: ${{ needs.build.outputs.prerelease }}
 
       - name: Upload release files on Github
         uses: svenstaro/upload-release-action@v2
@@ -574,10 +572,10 @@ jobs:
 
       - name: Upload release files on Arduino downloads servers
         run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
-        if: steps.prerelease.outputs.IS_PRE != 'true'
+        if: ${{ needs.build.outputs.prerelease != 'true' }}
 
       - name: Update version file (used by frontend to trigger autoupdate and create filename)
         run: |
           echo {\"Version\": \"${GITHUB_REF##*/}\"} > /tmp/agent-version.json
           aws s3 cp /tmp/agent-version.json s3://${{ env.VERSION_TARGET }}
-        if: steps.prerelease.outputs.IS_PRE != 'true'
+        if: ${{ needs.build.outputs.prerelease != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,9 @@ jobs:
 
       - name: Build the Agent for macos
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.11 # minimum supported version for mac
-          CGO_CFLAGS: -mmacosx-version-min=10.11
-          CGO_LDFLAGS: -mmacosx-version-min=10.11
+          MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.15
+          CGO_LDFLAGS: -mmacosx-version-min=10.15
         run: task go:build
         if: matrix.os == 'macos-12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,14 @@ jobs:
         run: go-selfupdate ${{ env.PROJECT_NAME }}${{ matrix.ext }} ${TAG_VERSION}
         if: matrix.arch != '-386' && steps.prerelease.outputs.IS_PRE != 'true'
 
+        # for now we do not distribute m1 build, this is a workaround for now
+      - name: Copy autoupdate file for darwin-arm64 (m1 arch)
+        working-directory: public/
+        run: | 
+          cp darwin-amd64.json darwin-arm64.json
+          cp ${TAG_VERSION}/darwin-amd64.gz ${TAG_VERSION}/darwin-arm64.gz
+        if: matrix.os == `macos-12` && steps.prerelease.outputs.IS_PRE != 'true'
+
       - name: Create autoupdate files for win32
         run: go-selfupdate -platform windows${{ matrix.arch }} ${{ env.PROJECT_NAME }}${{ matrix.ext }} ${TAG_VERSION}
         if: matrix.arch == '-386' && matrix.os == 'windows-2019' && steps.prerelease.outputs.IS_PRE != 'true'
@@ -144,6 +152,11 @@ jobs:
   create-macos-bundle:
     needs: build
 
+    # for not they are exaclty the same
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+
     runs-on: macos-12
     env:
       EXE_PATH: "skel/ArduinoCreateAgent.app/Contents/MacOS/"
@@ -158,7 +171,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.PROJECT_NAME }}-macos-12-amd64
+          name: ${{ env.PROJECT_NAME }}-macos-12-amd64 # if we want to support darwin-arm64 in the future for real this has to change.
           path: ${{ env.EXE_PATH }}
 
       - name: Remove placeholder file
@@ -197,18 +210,24 @@ jobs:
           EOF
 
       - name: Tar bundle to keep permissions
-        run: tar -cvf ArduinoCreateAgent.app.tar -C skel/ .
+        run: tar -cvf ArduinoCreateAgent.app_${{ matrix.arch }}.tar -C skel/ .
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
-          name: ArduinoCreateAgent.app
-          path: ArduinoCreateAgent.app.tar
+          name: ArduinoCreateAgent.app_${{ matrix.arch }}
+          path: ArduinoCreateAgent.app_${{ matrix.arch }}.tar
           
   # The notarize-macos job will download the macos bundle from the previous job, sign, notarize and re-upload it, uploading it also on s3 download servers for the autoupdate.
   notarize-macos:
     name: Notarize bundle
+
+    # for not they are exaclty the same
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+
     runs-on: macos-12
     env:
       GON_PATH: ${{ github.workspace }}/gon
@@ -218,10 +237,10 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ArduinoCreateAgent.app
+          name: ArduinoCreateAgent.app_${{ matrix.arch }}
 
       - name: un-Tar bundle
-        run: tar -xvf ArduinoCreateAgent.app.tar
+        run: tar -xvf ArduinoCreateAgent.app_${{ matrix.arch }}.tar
 
       - name: Import Code-Signing Certificates
         run: |
@@ -272,7 +291,7 @@ jobs:
           # Ask Gon for zip output to force notarization process to take place.
           # The CI will upload the zip output
           zip {
-            output_path = "ArduinoCreateAgent.app_notarized.zip"
+            output_path = "ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip"
           }
           EOF
 
@@ -280,14 +299,29 @@ jobs:
         run: gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
         
       - name: Upload autoupdate bundle to Arduino downloads servers
-        run: aws s3 cp ArduinoCreateAgent.app_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}${GITHUB_REF/refs\/tags\//}/ # the version should be created in th the build job
+        run: aws s3 cp ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}${GITHUB_REF/refs\/tags\//}/ # the version should be created in th the build job
+        if: ${{ needs.build.outputs.prerelease != 'true' }}
+
+      - name: Generate json file used for the new autoupdate
+        run: |
+          cat > darwin-${{ matrix.arch }}-bundle.json <<EOF
+          {
+              "Version": "${GITHUB_REF/refs\/tags\//}",
+              "Sha256": "$(shasum -a 256 ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip | awk '{print $1}' |  xxd -r -p | base64)"
+          }
+          EOF
+        if: ${{ needs.build.outputs.prerelease != 'true' }}
+
+      - name: Upload autoupdate files to Arduino downloads servers
+        run: |
+          aws s3 cp darwin-${{ matrix.arch }}-bundle.json s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
         if: ${{ needs.build.outputs.prerelease != 'true' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ArduinoCreateAgent.app_notarized
-          path: ArduinoCreateAgent.app_notarized.zip
+          name: ArduinoCreateAgent.app_${{ matrix.arch }}_notarized
+          path: ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip
           if-no-files-found: error
 
   # This job is responsible for generating the installers (using installbuilder)
@@ -340,7 +374,8 @@ jobs:
             install-builder-name: osx
             executable-path: artifacts/macos/ArduinoCreateAgent.app
             installer-extension: .app
-            artifact-name: ArduinoCreateAgent.app_notarized # this artifact contains the Contents directory
+            artifact-name: ArduinoCreateAgent.app_amd64_notarized # this artifact contains the Contents directory
+            # here we support only amd64 for macos. Hopefully in the future installbuilder for macOS will be removed, see https://github.com/arduino/arduino-create-agent/issues/739
 
     container:
       image: floydpink/ubuntu-install-builder:22.10.0

--- a/update.go
+++ b/update.go
@@ -41,5 +41,9 @@ func updateHandler(c *gin.Context) {
 		return
 	}
 	c.JSON(200, gin.H{"success": "Please wait a moment while the agent reboots itself"})
-	Systray.RestartWith(restartPath)
+	if restartPath == "quit" {
+		Systray.Quit()
+	} else {
+		Systray.RestartWith(restartPath)
+	}
 }

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -15,10 +15,105 @@
 
 package updater
 
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/codeclysm/extract/v3"
+)
+
 func start(src string) string {
 	return ""
 }
 
 func checkForUpdates(currentVersion string, updateAPIURL, updateBinURL string, cmdName string) (string, error) {
-	return "", nil
+	executablePath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("could not app path: %w", err)
+	}
+	currentAppPath := paths.New(executablePath).Parent().Parent().Parent()
+	if currentAppPath.Ext() != ".app" {
+		return "", fmt.Errorf("could not find app root in %s", executablePath)
+	}
+	oldAppPath := currentAppPath.Parent().Join("ArdiunoCreateAgent.old.app")
+	if oldAppPath.Exist() {
+		return "", fmt.Errorf("temp app already exists: %s, cannot update", oldAppPath)
+	}
+
+	// Fetch information about updates
+	info, err := fetchInfo(updateAPIURL, cmdName)
+	if err != nil {
+		return "", err
+	}
+	if info.Version == currentVersion {
+		// No updates available, bye bye
+		return "", nil
+	}
+
+	tmp := paths.TempDir().Join("arduino-create-agent")
+	tmpZip := tmp.Join("update.zip")
+	tmpAppPath := tmp.Join("ArduinoCreateAgent-update.app")
+	defer tmp.RemoveAll()
+
+	// Download the update.
+	download, err := fetch(updateBinURL + cmdName + "/" + plat + "/" + info.Version + "/" + cmdName)
+	if err != nil {
+		return "", err
+	}
+	defer download.Close()
+
+	f, err := tmpZip.Create()
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	sha := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(sha, f), download); err != nil {
+		return "", err
+	}
+	f.Close()
+
+	// Check the hash
+	if s := sha.Sum(nil); !bytes.Equal(s, info.Sha256) {
+		return "", fmt.Errorf("bad hash: %s (expected %s)", s, info.Sha256)
+	}
+
+	// Unzip the update
+	if err := tmpAppPath.MkdirAll(); err != nil {
+		return "", fmt.Errorf("could not create tmp dir to unzip update: %w", err)
+	}
+
+	f, err = tmpZip.Open()
+	if err != nil {
+		return "", fmt.Errorf("could not open archive for unzip: %w", err)
+	}
+	defer f.Close()
+	if err := extract.Archive(context.Background(), f, tmpAppPath.String(), nil); err != nil {
+		return "", fmt.Errorf("extracting archive: %w", err)
+	}
+
+	// Rename current app as .old
+	if err := currentAppPath.Rename(oldAppPath); err != nil {
+		return "", fmt.Errorf("could not rename old app as .old: %w", err)
+	}
+
+	// Install new app
+	if err := tmpAppPath.CopyDirTo(currentAppPath); err != nil {
+		// Try rollback changes
+		_ = currentAppPath.RemoveAll()
+		_ = oldAppPath.Rename(currentAppPath)
+		return "", fmt.Errorf("could not install app: %w", err)
+	}
+
+	// Remove old app
+	_ = oldAppPath.RemoveAll()
+
+	// Restart agent
+	return currentAppPath.Join("Contents", "MacOS", "Arduino_Create_Agent").String(), nil
 }

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -15,6 +15,29 @@
 
 package updater
 
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa
+#import <Cocoa/Cocoa.h>
+
+void runApplication(const char *path) {
+	NSWorkspace *ws = [NSWorkspace sharedWorkspace];
+	NSURL *url = [NSURL fileURLWithPath:@(path) isDirectory:NO];
+
+	NSWorkspaceOpenConfiguration* configuration = [NSWorkspaceOpenConfiguration new];
+	//[configuration setEnvironment:env];
+	[configuration setPromptsUserIfNeeded:YES];
+	[configuration setCreatesNewApplicationInstance:YES];
+
+	dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+	[ws openApplicationAtURL:url configuration:configuration completionHandler:^(NSRunningApplication* app, NSError* error) {
+		dispatch_semaphore_signal(semaphore);
+	}];
+	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+}
+*/
+import "C"
+
 import (
 	"bytes"
 	"context"
@@ -125,7 +148,9 @@ func checkForUpdates(currentVersion string, updateAPIURL, updateBinURL string, c
 	_ = oldAppPath.RemoveAll()
 
 	// Restart agent
-	newExecutable := currentAppPath.Join("Contents", "MacOS", "Arduino_Create_Agent")
-	logrus.WithField("path", newExecutable).Info("Running new app")
-	return newExecutable.String(), nil
+	logrus.WithField("path", currentAppPath).Info("Running new app")
+	C.runApplication(C.CString(currentAppPath.String()))
+
+	// Close old agent
+	return "quit", nil
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Enhancements
- **What is the current behavior?**

  - MacOS Ventura does not like that the agent binary creates files in the same directory where the binary sits
  - The agent was not able to generate the config file on firts run

- **What is the new behavior?**
<!-- if this is a feature change -->

1. `config.ini`:
     - The config searching/creation has been enhanced, now the agent is able to generate the config on first start (for more details see #733)
     - I've added the possibility to specify the config path with a special env var: `ARDUINO_CREATE_AGENT_CONFIG`
  2. `additional-config.ini` needed some change as well. Now it's handled correctly but in the user dir and not in the binary folder.
  3. `logs/` directory containing crash reports has been moved to user dir.
  4. Along the way I removed some unused functionality, like the "embeddedAutoextract" feature, which has never been used and used the [`embed`  package](https://pkg.go.dev/embed) to remove duplicated files

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
yes, docs need to be updated accordingly after the merge
* **Other information**:
<!-- Any additional information that could help the review process -->

Some of the commits are part of the [1.2.7-ventura release](https://github.com/arduino/arduino-create-agent/releases/tag/1.2.7-ventura)
