### PR TITLE
Fix amd64 darwin install wrong tool (amd64)

### DIFF
--- a/.licenses/arduino-create-agent/go/github.com/xrash/smetrics.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/xrash/smetrics.dep.yml
@@ -1,9 +1,8 @@
 ---
 name: github.com/xrash/smetrics
-version: v0.0.0-20201216005158-039620a65673
+version: v0.0.0-20170218160415-a3153f7040e9
 type: go
-summary: Package smetrics provides a bunch of algorithms for calculating the distance
-  between strings.
+summary: 
 homepage: https://pkg.go.dev/github.com/xrash/smetrics
 license: mit
 licenses:

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/stretchr/testify v1.8.1
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673
+	github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9
 	go.bug.st/downloader/v2 v2.1.1
 	go.bug.st/serial v1.4.1
 	goa.design/goa v1.0.1-0.20190116060309-40843d63b0e4

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/andela/gin-cors v0.0.0-20160928171741-e8c3436a37e2
 	github.com/arduino/arduino-cli v0.0.0-20210422154105-5aa424818026
+	github.com/arduino/go-paths-helper v1.8.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/codeclysm/extract/v3 v3.1.0
 	github.com/getlantern/systray v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,9 @@ github.com/arduino/arduino-cli v0.0.0-20210422154105-5aa424818026/go.mod h1:5dWr
 github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c/go.mod h1:HK7SpkEax/3P+0w78iRQx1sz1vCDYYw9RXwHjQTB5i8=
 github.com/arduino/go-paths-helper v1.0.1/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
 github.com/arduino/go-paths-helper v1.2.0/go.mod h1:HpxtKph+g238EJHq4geEPv9p+gl3v5YYu35Yb+w31Ck=
-github.com/arduino/go-paths-helper v1.4.0 h1:ilnseAdxmN1bFnLxxXHRtcdmt9jBf3O4jtYfWfqule4=
 github.com/arduino/go-paths-helper v1.4.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
+github.com/arduino/go-paths-helper v1.8.0 h1:BfA1bq1XktnlqwfUDCoKbUqB3YFPe6X7szPSZj6Rdpk=
+github.com/arduino/go-paths-helper v1.8.0/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4Qyx+RAFKaG9NuvU=
 github.com/arduino/go-properties-orderedmap v1.3.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b/go.mod h1:iIPnclBMYm1g32Q5kXoqng4jLhMStReIP7ZxaoUC2y8=

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 h1:w8V9v0qVympSF6GjdjIyeqR7+EVhAF9CBQmkmW7Zw0w=
+github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea h1:CyhwejzVGvZ3Q2PSbQ4NRRYn+ZWv5eS1vlaEusT+bAI=
 github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea/go.mod h1:eNr558nEUjP8acGw8FFjTeWvSgU1stO7FAO6eknhHe4=
 go.bug.st/cleanup v1.0.0/go.mod h1:EqVmTg2IBk4znLbPD28xne3abjsJftMdqqJEjhn70bk=

--- a/tools/download.go
+++ b/tools/download.go
@@ -67,7 +67,8 @@ type index struct {
 var systems = map[string]string{
 	"linuxamd64":   "x86_64-linux-gnu",
 	"linux386":     "i686-linux-gnu",
-	"darwinamd64":  "apple-darwin",
+	"darwinamd64":  "i686-apple-darwin",
+	"darwinarm64":  "arm64-apple-darwin",
 	"windows386":   "i686-mingw32",
 	"windowsamd64": "i686-mingw32",
 	"linuxarm":     "arm-linux-gnueabihf",

--- a/tools/download.go
+++ b/tools/download.go
@@ -73,6 +73,12 @@ var systems = map[string]string{
 	"linuxarm":     "arm-linux-gnueabihf",
 }
 
+// public vars to allow override in the tests
+var (
+	OS   = runtime.GOOS
+	Arch = runtime.GOARCH
+)
+
 func mimeType(data []byte) (string, error) {
 	return http.DetectContentType(data[0:512]), nil
 }
@@ -321,7 +327,7 @@ func findTool(pack, name, version string, data index) (tool, system) {
 	maxSimilarity := 0.7
 
 	for _, s := range correctTool.Systems {
-		similarity := smetrics.Jaro(s.Host, systems[runtime.GOOS+runtime.GOARCH])
+		similarity := smetrics.Jaro(s.Host, systems[OS+Arch])
 		if similarity > maxSimilarity {
 			correctSystem = s
 			maxSimilarity = similarity
@@ -587,7 +593,7 @@ func (t *Tools) installDrivers(location string) error {
 	OkPressed := 6
 	extension := ".bat"
 	preamble := ""
-	if runtime.GOOS != "windows" {
+	if OS != "windows" {
 		extension = ".sh"
 		// add ./ to force locality
 		preamble = "./"
@@ -599,7 +605,7 @@ func (t *Tools) installDrivers(location string) error {
 			os.Chdir(location)
 			t.Logger(preamble + "post_install" + extension)
 			oscmd := exec.Command(preamble + "post_install" + extension)
-			if runtime.GOOS != "linux" {
+			if OS != "linux" {
 				// spawning a shell could be the only way to let the user type his password
 				TellCommandNotToSpawnShell(oscmd)
 			}

--- a/tools/download_test.go
+++ b/tools/download_test.go
@@ -16,6 +16,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,8 +24,45 @@ import (
 	"path"
 	"testing"
 
+	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDownloadCorrectPlatform(t *testing.T) {
+	testCases := []struct {
+		hostOS        string
+		hostArch      string
+		correctOSArch string
+	}{
+		{"linux", "amd64", "x86_64-linux-gnu"},
+		{"linux", "386", "i686-linux-gnu"},
+		{"darwin", "amd64", "x86_64-apple-darwin"},
+		{"windows", "386", "i686-mingw32"},
+		{"windows", "amd64", "i686-mingw32"},
+		{"linux", "arm", "arm-linux-gnueabihf"},
+	}
+	testIndex := paths.New("testdata", "test_tool_index.json")
+	buf, err := testIndex.ReadFile()
+	require.NoError(t, err)
+
+	var data index
+	err = json.Unmarshal(buf, &data)
+	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.hostOS+tc.hostArch, func(t *testing.T) {
+			OS = tc.hostOS     // override `runtime.OS` for testing purposes
+			Arch = tc.hostArch // override `runtime.ARCH` for testing purposes
+			// Find the tool by name
+			correctTool, correctSystem := findTool("arduino-test", "arduino-fwuploader", "2.2.2", data)
+			require.NotNil(t, correctTool)
+			require.NotNil(t, correctSystem)
+			require.Equal(t, correctTool.Name, "arduino-fwuploader")
+			require.Equal(t, correctTool.Version, "2.2.2")
+			require.Equal(t, correctSystem.Host, tc.correctOSArch)
+		})
+	}
+}
 
 func Test_findBaseDir(t *testing.T) {
 	cases := []struct {

--- a/tools/download_test.go
+++ b/tools/download_test.go
@@ -38,6 +38,7 @@ func TestDownloadCorrectPlatform(t *testing.T) {
 		{"linux", "amd64", "x86_64-linux-gnu"},
 		{"linux", "386", "i686-linux-gnu"},
 		{"darwin", "amd64", "x86_64-apple-darwin"},
+		{"darwin", "arm64", "arm64-apple-darwin"},
 		{"windows", "386", "i686-mingw32"},
 		{"windows", "amd64", "i686-mingw32"},
 		{"linux", "arm", "arm-linux-gnueabihf"},

--- a/tools/testdata/test_tool_index.json
+++ b/tools/testdata/test_tool_index.json
@@ -1,0 +1,117 @@
+{
+    "packages": [
+        {
+            "name": "arduino-test",
+            "maintainer": "Arduino",
+            "websiteURL": "http://www.arduino.cc/",
+            "email": "packages@arduino.cc",
+            "help": {
+                "online": "http://www.arduino.cc/en/Reference/HomePage"
+            },
+            "platforms": [
+                {
+                    "name": "Arduino megaAVR Boards - Pre-release",
+                    "architecture": "megaavr",
+                    "version": "1.8.102",
+                    "category": "Arduino",
+                    "url": "http://downloads.arduino.cc/cores/staging/core-megaavr-1.8.102.tar.bz2",
+                    "archiveFileName": "core-megaavr-1.8.102.tar.bz2",
+                    "checksum": "SHA-256:ad5e60b828678d9ccff957032524a4c4d68b218737e7df24b905769a04dc2a6a",
+                    "size": "858620",
+                    "help": {
+                        "online": "https://github.com/arduino/ArduinoCore-megaavr/issues"
+                    },
+                    "boards": [
+                        {
+                            "name": "Arduino Uno WiFi Rev2"
+                        },
+                        {
+                            "name": "Arduino Nano Every"
+                        }
+                    ],
+                    "toolsDependencies": [
+                        {
+                            "packager": "arduino",
+                            "name": "avr-gcc",
+                            "version": "7.3.0-atmel3.6.1-arduino5"
+                        },
+                        {
+                            "packager": "arduino",
+                            "name": "avrdude",
+                            "version": "7.0-arduino.3"
+                        },
+                        {
+                            "packager": "arduino",
+                            "name": "arduinoOTA",
+                            "version": "1.3.0"
+                        }
+                    ]
+                }
+            ],
+            "tools": [
+                {
+                    "name": "arduino-fwuploader",
+                    "version": "2.2.2",
+                    "systems": [
+                      {
+                        "host": "i686-linux-gnu",
+                        "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.2.2_Linux_32bit.tar.gz",
+                        "archiveFileName": "arduino-fwuploader_2.2.2_Linux_32bit.tar.gz",
+                        "checksum": "SHA-256:503b9f8b24c6e396d09eb64f0e1f625c6f9aa5a90b01a50d7dec6477f4a866f0",
+                        "size": "7262873"
+                      },
+                      {
+                        "host": "x86_64-linux-gnu",
+                        "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.2.2_Linux_64bit.tar.gz",
+                        "archiveFileName": "arduino-fwuploader_2.2.2_Linux_64bit.tar.gz",
+                        "checksum": "SHA-256:8d77d0b33c8b0787fe3b80191709b69d638ef2a447d9853536cda35bfafd274b",
+                        "size": "7306763"
+                      },
+                      {
+                        "host": "i686-mingw32",
+                        "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.2.2_Windows_32bit.zip",
+                        "archiveFileName": "arduino-fwuploader_2.2.2_Windows_32bit.zip",
+                        "checksum": "SHA-256:74ad9a5d369204b51be288c98d74f949ceb7a0c227ee64eb65ae179ec884c84c",
+                        "size": "7450717"
+                      },
+                      {
+                        "host": "x86_64-mingw32",
+                        "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.2.2_Windows_64bit.zip",
+                        "archiveFileName": "arduino-fwuploader_2.2.2_Windows_64bit.zip",
+                        "checksum": "SHA-256:b25ac549cb0645166613c96cf899aebc541e482fe196aada6408bd7cff2c7d02",
+                        "size": "7390999"
+                      },
+                      {
+                        "host": "x86_64-apple-darwin",
+                        "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.2.2_macOS_64bit.tar.gz",
+                        "archiveFileName": "arduino-fwuploader_2.2.2_macOS_64bit.tar.gz",
+                        "checksum": "SHA-256:2cd6168ff470457b5124ba0faf118f315be2d1b9fb4fef43eb74370cd83620a2",
+                        "size": "7306576"
+                      },
+                      {
+                        "host": "arm64-apple-darwin",
+                        "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.2.2_macOS_ARM64.tar.gz",
+                        "archiveFileName": "arduino-fwuploader_2.2.2_macOS_ARM64.tar.gz",
+                        "checksum": "SHA-256:10ae5614af4d82096b6ba0e1e07aab667fa140d2bf1d5e3407dd8ad4c6748195",
+                        "size": "6878214"
+                      },
+                      {
+                        "host": "arm-linux-gnueabihf",
+                        "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.2.2_Linux_ARMv6.tar.gz",
+                        "archiveFileName": "arduino-fwuploader_2.2.2_Linux_ARMv6.tar.gz",
+                        "checksum": "SHA-256:5aadf6e50ffe620635faf941fdf82c0765c8cba4830951bb53267ad125fc5af8",
+                        "size": "6940393"
+                      },
+                      {
+                        "host": "aarch64-linux-gnu",
+                        "url": "http://downloads.arduino.cc/arduino-fwuploader/arduino-fwuploader_2.2.2_Linux_ARM64.tar.gz",
+                        "archiveFileName": "arduino-fwuploader_2.2.2_Linux_ARM64.tar.gz",
+                        "checksum": "SHA-256:6d11a4f4aa5a81de865f3d18ca395a2780fdbb1e1597a2b11b2b5329e09f30fd",
+                        "size": "6829396"
+                      }
+                    ]
+                  }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [X] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Fix #751 
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
See #751 

* **What is the new behavior?**
<!-- if this is a feature change -->
The agent should be able to select the correct tool system to download
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
