### PR TITLE
Upload the signed bundle to s3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   # The build job is responsible for: configuring the environment, testing and compiling process
   build:
+    outputs:
+      prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-12]
@@ -493,7 +495,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-20.04
-    needs: code-sign-mac-installers
+    needs: [build, code-sign-mac-installers]
 
     steps:
       - name: Checkout
@@ -503,14 +505,6 @@ jobs:
 
       - name: Download artifact
         uses: actions/download-artifact@v3 # download all the artifacts
-
-      - name: Identify Prerelease
-        # This is a workaround while waiting for create-release action to implement auto pre-release based on tag
-        id: prerelease
-        run: |
-          curl -L -s https://github.com/fsaintjacques/semver-tool/archive/3.1.0.zip -o /tmp/3.1.0.zip
-          unzip -p /tmp/3.1.0.zip semver-tool-3.1.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ $(/tmp/semver get prerel ${GITHUB_REF/refs\/tags\//}) ]]; then echo "IS_PRE=true" >> $GITHUB_OUTPUT; fi
 
       #  mandatory step because upload-release-action does not support multiple folders
       - name: prepare artifacts for the release
@@ -562,7 +556,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: ${{ steps.release_body.outputs.RBODY}}
           draft: false
-          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+          prerelease: ${{ needs.build.outputs.prerelease }}
 
       - name: Upload release files on Github
         uses: svenstaro/upload-release-action@v2
@@ -574,10 +568,10 @@ jobs:
 
       - name: Upload release files on Arduino downloads servers
         run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
-        if: steps.prerelease.outputs.IS_PRE != 'true'
+        if: ${{ needs.build.outputs.prerelease }} != 'true'
 
       - name: Update version file (used by frontend to trigger autoupdate and create filename)
         run: |
           echo {\"Version\": \"${GITHUB_REF##*/}\"} > /tmp/agent-version.json
           aws s3 cp /tmp/agent-version.json s3://${{ env.VERSION_TARGET }}
-        if: steps.prerelease.outputs.IS_PRE != 'true'
+        if: ${{ needs.build.outputs.prerelease }} != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,7 @@ jobs:
         run: gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
         
       - name: Upload autoupdate bundle to Arduino downloads servers
-        run: aws s3 cp ArduinoCreateAgent.app_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
+        run: aws s3 cp ArduinoCreateAgent.app_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}${GITHUB_REF/refs\/tags\//}/ # the version should be created in th the build job
         if: ${{ needs.build.outputs.prerelease }} != 'true'
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: arduino-create-agent
-  TARGET: "/CreateAgent/Stable"
+  TARGET: "/CreateAgent/Stable/"
   OLD_TARGET: "/CreateBridge/" # compatibility with older releases (we can't change config.ini)
   VERSION_TARGET: "arduino-create-static/agent-metadata/"
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -206,13 +206,13 @@ jobs:
           name: ArduinoCreateAgent.app
           path: ArduinoCreateAgent.app.tar
           
-  # The notarize-macos job will download the macos bundle from the previous job, sign, notarize and re-upload it.
+  # The notarize-macos job will download the macos bundle from the previous job, sign, notarize and re-upload it, uploading it also on s3 download servers for the autoupdate.
   notarize-macos:
     name: Notarize bundle
     runs-on: macos-12
     env:
       GON_PATH: ${{ github.workspace }}/gon
-    needs: create-macos-bundle
+    needs: [build, create-macos-bundle]
 
     steps:
       - name: Download artifact
@@ -278,6 +278,10 @@ jobs:
 
       - name: Sign and notarize binary
         run: gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
+        
+      - name: Upload autoupdate bundle to Arduino downloads servers
+        run: aws s3 cp ArduinoCreateAgent.app_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
+        if: ${{ needs.build.outputs.prerelease }} != 'true'
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
CI enhancement
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The autoupdate bundle is not pushed to s3 download servers
* **What is the new behavior?**
<!-- if this is a feature change -->
During a release, a notarized zipped bundle is produced and pushed directly to s3 download server, inside a directory that includes the version tag.
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
Close #736 