### PR TITLE
Add "Open config file" menu item

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,6 +255,7 @@ func loop() {
 	if err != nil {
 		log.Panicf("cannot parse arguments: %s", err)
 	}
+	Systray.SetCurrentConfigFile(configPath)
 
 	// Parse additional ini config if defined
 	if len(*additionalConfig) > 0 {

--- a/main.go
+++ b/main.go
@@ -136,6 +136,10 @@ func main() {
 	go loop()
 
 	// SetupSystray is the main thread
+	configDir, err := getDefaultArduinoCreateConfigDir()
+	if err != nil {
+		log.Panicf("Can't open defaul configuration dir: %s", err)
+	}
 	Systray = systray.Systray{
 		Hibernate: *hibernate,
 		Version:   version + "-" + commit,
@@ -143,6 +147,7 @@ func main() {
 			return "http://" + *address + port
 		},
 		AdditionalConfig: *additionalConfig,
+		ConfigDir:        configDir,
 	}
 
 	path, err := os.Executable()

--- a/systray/systray.go
+++ b/systray/systray.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/arduino/go-paths-helper"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -38,6 +39,8 @@ type Systray struct {
 	ConfigDir *paths.Path
 	// The path of the exe (only used in update)
 	path string
+	// The path of the configuration file
+	currentConfigFilePath *paths.Path
 }
 
 // Restart restarts the program
@@ -93,4 +96,10 @@ func (s *Systray) Resume() {
 func (s *Systray) Update(path string) {
 	s.path = path
 	s.Restart()
+}
+
+// SetCurrentConfigFile allows to specify the path of the configuration file the agent
+// is using. The tray menu with this info can display an "open config file" option.
+func (s *Systray) SetCurrentConfigFile(configPath *paths.Path) {
+	s.currentConfigFilePath = configPath
 }

--- a/systray/systray.go
+++ b/systray/systray.go
@@ -34,6 +34,8 @@ type Systray struct {
 	DebugURL func() string
 	// The active configuration file
 	AdditionalConfig string
+	// The path to the directory containing the configuration files
+	ConfigDir *paths.Path
 	// The path of the exe (only used in update)
 	path string
 }

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -57,6 +57,7 @@ func (s *Systray) start() {
 	// Add links
 	mURL := systray.AddMenuItem("Go to Arduino Create", "Arduino Create")
 	mDebug := systray.AddMenuItem("Open Debug Console", "Debug console")
+	mConfig := systray.AddMenuItem("Open Configuration", "Config File")
 
 	// Remove crash-reports
 	mRmCrashes := systray.AddMenuItem("Remove crash reports", "")
@@ -78,6 +79,8 @@ func (s *Systray) start() {
 				_ = open.Start("https://create.arduino.cc")
 			case <-mDebug.ClickedCh:
 				_ = open.Start(s.DebugURL())
+			case <-mConfig.ClickedCh:
+				_ = open.Start(s.currentConfigFilePath.String())
 			case <-mRmCrashes.ClickedCh:
 				s.RemoveCrashes()
 				s.updateMenuItem(mRmCrashes, s.CrashesIsEmpty())


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
Adds the "Open Config..." menu item, to open the current configuration file.

- **What is the current behavior?**
"Open Config file" menu is missing.

* **What is the new behavior?**

- **Does this PR introduce a breaking change?**

* **Other information**:
Fix #734 