### PR TITLE
Fix macosx ventura updater

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -132,9 +132,9 @@ jobs:
 
       - name: Build the Agent for macos
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.11 # minimum supported version for mac
-          CGO_CFLAGS: -mmacosx-version-min=10.11
-          CGO_LDFLAGS: -mmacosx-version-min=10.11
+          MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.15
+          CGO_LDFLAGS: -mmacosx-version-min=10.15
         run: task go:build
         if: runner.os == 'macOS'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 env:
   # As defined by the Taskfile's PROJECT_NAME variable
   PROJECT_NAME: arduino-create-agent
-  TARGET: "/CreateAgent/Stable"
+  TARGET: "/CreateAgent/Stable/"
   OLD_TARGET: "/CreateBridge/" # compatibility with older releases (we can't change config.ini)
   VERSION_TARGET: "arduino-create-static/agent-metadata/"
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -26,6 +26,8 @@ env:
 jobs:
   # The build job is responsible for: configuring the environment, testing and compiling process
   build:
+    outputs:
+      prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-12]
@@ -204,13 +206,13 @@ jobs:
           name: ArduinoCreateAgent.app
           path: ArduinoCreateAgent.app.tar
           
-  # The notarize-macos job will download the macos bundle from the previous job, sign, notarize and re-upload it.
+  # The notarize-macos job will download the macos bundle from the previous job, sign, notarize and re-upload it, uploading it also on s3 download servers for the autoupdate.
   notarize-macos:
     name: Notarize bundle
     runs-on: macos-12
     env:
       GON_PATH: ${{ github.workspace }}/gon
-    needs: create-macos-bundle
+    needs: [build, create-macos-bundle]
 
     steps:
       - name: Download artifact
@@ -276,6 +278,10 @@ jobs:
 
       - name: Sign and notarize binary
         run: gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
+        
+      - name: Upload autoupdate bundle to Arduino downloads servers
+        run: aws s3 cp ArduinoCreateAgent.app_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}${GITHUB_REF/refs\/tags\//}/ # the version should be created in th the build job
+        if: ${{ needs.build.outputs.prerelease != 'true' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -493,7 +499,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-20.04
-    needs: code-sign-mac-installers
+    needs: [build, code-sign-mac-installers]
 
     steps:
       - name: Checkout
@@ -503,14 +509,6 @@ jobs:
 
       - name: Download artifact
         uses: actions/download-artifact@v3 # download all the artifacts
-
-      - name: Identify Prerelease
-        # This is a workaround while waiting for create-release action to implement auto pre-release based on tag
-        id: prerelease
-        run: |
-          curl -L -s https://github.com/fsaintjacques/semver-tool/archive/3.1.0.zip -o /tmp/3.1.0.zip
-          unzip -p /tmp/3.1.0.zip semver-tool-3.1.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ $(/tmp/semver get prerel ${GITHUB_REF/refs\/tags\//}) ]]; then echo "IS_PRE=true" >> $GITHUB_OUTPUT; fi
 
       #  mandatory step because upload-release-action does not support multiple folders
       - name: prepare artifacts for the release
@@ -562,7 +560,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: ${{ steps.release_body.outputs.RBODY}}
           draft: false
-          prerelease: ${{ steps.prerelease.outputs.IS_PRE }}
+          prerelease: ${{ needs.build.outputs.prerelease }}
 
       - name: Upload release files on Github
         uses: svenstaro/upload-release-action@v2
@@ -574,10 +572,10 @@ jobs:
 
       - name: Upload release files on Arduino downloads servers
         run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
-        if: steps.prerelease.outputs.IS_PRE != 'true'
+        if: ${{ needs.build.outputs.prerelease != 'true' }}
 
       - name: Update version file (used by frontend to trigger autoupdate and create filename)
         run: |
           echo {\"Version\": \"${GITHUB_REF##*/}\"} > /tmp/agent-version.json
           aws s3 cp /tmp/agent-version.json s3://${{ env.VERSION_TARGET }}
-        if: steps.prerelease.outputs.IS_PRE != 'true'
+        if: ${{ needs.build.outputs.prerelease != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,9 @@ jobs:
 
       - name: Build the Agent for macos
         env:
-          MACOSX_DEPLOYMENT_TARGET: 10.11 # minimum supported version for mac
-          CGO_CFLAGS: -mmacosx-version-min=10.11
-          CGO_LDFLAGS: -mmacosx-version-min=10.11
+          MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.15
+          CGO_LDFLAGS: -mmacosx-version-min=10.15
         run: task go:build
         if: matrix.os == 'macos-12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,14 @@ jobs:
         run: go-selfupdate ${{ env.PROJECT_NAME }}${{ matrix.ext }} ${TAG_VERSION}
         if: matrix.arch != '-386' && steps.prerelease.outputs.IS_PRE != 'true'
 
+        # for now we do not distribute m1 build, this is a workaround for now
+      - name: Copy autoupdate file for darwin-arm64 (m1 arch)
+        working-directory: public/
+        run: | 
+          cp darwin-amd64.json darwin-arm64.json
+          cp ${TAG_VERSION}/darwin-amd64.gz ${TAG_VERSION}/darwin-arm64.gz
+        if: matrix.os == `macos-12` && steps.prerelease.outputs.IS_PRE != 'true'
+
       - name: Create autoupdate files for win32
         run: go-selfupdate -platform windows${{ matrix.arch }} ${{ env.PROJECT_NAME }}${{ matrix.ext }} ${TAG_VERSION}
         if: matrix.arch == '-386' && matrix.os == 'windows-2019' && steps.prerelease.outputs.IS_PRE != 'true'
@@ -144,6 +152,11 @@ jobs:
   create-macos-bundle:
     needs: build
 
+    # for not they are exaclty the same
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+
     runs-on: macos-12
     env:
       EXE_PATH: "skel/ArduinoCreateAgent.app/Contents/MacOS/"
@@ -158,7 +171,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ env.PROJECT_NAME }}-macos-12-amd64
+          name: ${{ env.PROJECT_NAME }}-macos-12-amd64 # if we want to support darwin-arm64 in the future for real this has to change.
           path: ${{ env.EXE_PATH }}
 
       - name: Remove placeholder file
@@ -197,18 +210,24 @@ jobs:
           EOF
 
       - name: Tar bundle to keep permissions
-        run: tar -cvf ArduinoCreateAgent.app.tar -C skel/ .
+        run: tar -cvf ArduinoCreateAgent.app_${{ matrix.arch }}.tar -C skel/ .
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error
-          name: ArduinoCreateAgent.app
-          path: ArduinoCreateAgent.app.tar
+          name: ArduinoCreateAgent.app_${{ matrix.arch }}
+          path: ArduinoCreateAgent.app_${{ matrix.arch }}.tar
           
   # The notarize-macos job will download the macos bundle from the previous job, sign, notarize and re-upload it, uploading it also on s3 download servers for the autoupdate.
   notarize-macos:
     name: Notarize bundle
+
+    # for not they are exaclty the same
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+
     runs-on: macos-12
     env:
       GON_PATH: ${{ github.workspace }}/gon
@@ -218,10 +237,10 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
-          name: ArduinoCreateAgent.app
+          name: ArduinoCreateAgent.app_${{ matrix.arch }}
 
       - name: un-Tar bundle
-        run: tar -xvf ArduinoCreateAgent.app.tar
+        run: tar -xvf ArduinoCreateAgent.app_${{ matrix.arch }}.tar
 
       - name: Import Code-Signing Certificates
         run: |
@@ -272,7 +291,7 @@ jobs:
           # Ask Gon for zip output to force notarization process to take place.
           # The CI will upload the zip output
           zip {
-            output_path = "ArduinoCreateAgent.app_notarized.zip"
+            output_path = "ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip"
           }
           EOF
 
@@ -280,14 +299,29 @@ jobs:
         run: gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
         
       - name: Upload autoupdate bundle to Arduino downloads servers
-        run: aws s3 cp ArduinoCreateAgent.app_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}${GITHUB_REF/refs\/tags\//}/ # the version should be created in th the build job
+        run: aws s3 cp ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}${GITHUB_REF/refs\/tags\//}/ # the version should be created in th the build job
+        if: ${{ needs.build.outputs.prerelease != 'true' }}
+
+      - name: Generate json file used for the new autoupdate
+        run: |
+          cat > darwin-${{ matrix.arch }}-bundle.json <<EOF
+          {
+              "Version": "${GITHUB_REF/refs\/tags\//}",
+              "Sha256": "$(shasum -a 256 ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip | awk '{print $1}' |  xxd -r -p | base64)"
+          }
+          EOF
+        if: ${{ needs.build.outputs.prerelease != 'true' }}
+
+      - name: Upload autoupdate files to Arduino downloads servers
+        run: |
+          aws s3 cp darwin-${{ matrix.arch }}-bundle.json s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
         if: ${{ needs.build.outputs.prerelease != 'true' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ArduinoCreateAgent.app_notarized
-          path: ArduinoCreateAgent.app_notarized.zip
+          name: ArduinoCreateAgent.app_${{ matrix.arch }}_notarized
+          path: ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip
           if-no-files-found: error
 
   # This job is responsible for generating the installers (using installbuilder)
@@ -340,7 +374,8 @@ jobs:
             install-builder-name: osx
             executable-path: artifacts/macos/ArduinoCreateAgent.app
             installer-extension: .app
-            artifact-name: ArduinoCreateAgent.app_notarized # this artifact contains the Contents directory
+            artifact-name: ArduinoCreateAgent.app_amd64_notarized # this artifact contains the Contents directory
+            # here we support only amd64 for macos. Hopefully in the future installbuilder for macOS will be removed, see https://github.com/arduino/arduino-create-agent/issues/739
 
     container:
       image: floydpink/ubuntu-install-builder:22.10.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,10 @@ jobs:
         # for now we do not distribute m1 build, this is a workaround for now
       - name: Copy autoupdate file for darwin-arm64 (m1 arch)
         working-directory: public/
-        run: | 
+        run: |
           cp darwin-amd64.json darwin-arm64.json
           cp ${TAG_VERSION}/darwin-amd64.gz ${TAG_VERSION}/darwin-arm64.gz
-        if: matrix.os == `macos-12` && steps.prerelease.outputs.IS_PRE != 'true'
+        if: matrix.os == 'macos-12' && steps.prerelease.outputs.IS_PRE != 'true'
 
       - name: Create autoupdate files for win32
         run: go-selfupdate -platform windows${{ matrix.arch }} ${{ env.PROJECT_NAME }}${{ matrix.ext }} ${TAG_VERSION}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-ini/ini v1.62.0
 	github.com/googollee/go-socket.io v0.0.0-20181101151912-c8aeb1ed9b49
-	github.com/kr/binarydist v0.1.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/oleksandr/bonjour v0.0.0-20210301155756-30f43c61b915
@@ -56,6 +55,7 @@ require (
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/klauspost/compress v1.15.13 // indirect
+	github.com/kr/binarydist v0.1.0 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d // indirect

--- a/systray/exec_darwin.go
+++ b/systray/exec_darwin.go
@@ -1,0 +1,60 @@
+package systray
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa
+#import <Cocoa/Cocoa.h>
+
+char **makeCharArray(int size) {
+	return calloc(sizeof(char*), size);
+}
+
+void setCharArray(char **a, int n, char *s) {
+	a[n] = s;
+}
+
+void freeCharArray(char **a, int size) {
+	int i;
+	for (i = 0; i < size; i++) {
+		free(a[i]);
+	}
+	free(a);
+}
+
+void runApplication(const char *path, const char **argv, int argc) {
+	NSMutableArray<NSString *> *stringArray = [NSMutableArray array];
+	for (int i=0; i<argc; i++) {
+		NSString *arg = [NSString stringWithCString:argv[i] encoding:NSUTF8StringEncoding];
+		[stringArray addObject:arg];
+	}
+	NSArray<NSString *> *arguments = [NSArray arrayWithArray:stringArray];
+
+	NSWorkspace *ws = [NSWorkspace sharedWorkspace];
+	NSURL *url = [NSURL fileURLWithPath:@(path) isDirectory:NO];
+
+	NSWorkspaceOpenConfiguration* configuration = [NSWorkspaceOpenConfiguration new];
+	//[configuration setEnvironment:env];
+	[configuration setPromptsUserIfNeeded:YES];
+	[configuration setCreatesNewApplicationInstance:YES];
+	[configuration setArguments:arguments];
+	dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+	[ws openApplicationAtURL:url configuration:configuration completionHandler:^(NSRunningApplication* app, NSError* error) {
+		dispatch_semaphore_signal(semaphore);
+	}];
+	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+}
+*/
+import "C"
+
+func execApp(path string, args ...string) error {
+	argc := C.int(len(args))
+	argv := C.makeCharArray(argc)
+	for i, arg := range args {
+		C.setCharArray(argv, C.int(i), C.CString(arg))
+	}
+
+	C.runApplication(C.CString(path), argv, argc)
+
+	C.freeCharArray(argv, argc)
+	return nil
+}

--- a/systray/exec_darwin.go
+++ b/systray/exec_darwin.go
@@ -48,15 +48,19 @@ import "C"
 import (
 	"os/exec"
 	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 )
 
 func execApp(path string, args ...string) error {
 	if filepath.Ext(path) != ".app" {
 		// If not .app, fallback to standard process execution
+		logrus.WithField("path", path).WithField("args", args).Info("Running new app with os/exec.Exec")
 		cmd := exec.Command(path, args...)
 		return cmd.Start()
 	}
 
+	logrus.WithField("path", path).WithField("args", args).Info("Running new app with openApplicationAtURL")
 	argc := C.int(len(args))
 	argv := C.makeCharArray(argc)
 	for i, arg := range args {

--- a/systray/exec_darwin.go
+++ b/systray/exec_darwin.go
@@ -45,8 +45,18 @@ void runApplication(const char *path, const char **argv, int argc) {
 }
 */
 import "C"
+import (
+	"os/exec"
+	"path/filepath"
+)
 
 func execApp(path string, args ...string) error {
+	if filepath.Ext(path) != ".app" {
+		// If not .app, fallback to standard process execution
+		cmd := exec.Command(path, args...)
+		return cmd.Start()
+	}
+
 	argc := C.int(len(args))
 	argv := C.makeCharArray(argc)
 	for i, arg := range args {

--- a/systray/exec_default.go
+++ b/systray/exec_default.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Arduino SA
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//go:build !darwin
+
+package systray
+
+import "os/exec"
+
+// default execApp from golang
+func execApp(path string, args ...string) error {
+	cmd := exec.Command(path, args...)
+	return cmd.Start()
+}

--- a/systray/systray.go
+++ b/systray/systray.go
@@ -18,7 +18,6 @@ package systray
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/arduino/go-paths-helper"
@@ -69,8 +68,7 @@ func (s *Systray) Restart() {
 	}
 
 	// Launch executable
-	cmd := exec.Command(s.path, args...)
-	err := cmd.Start()
+	err := execApp(s.path, args...)
 	if err != nil {
 		log.Printf("Error restarting process: %v\n", err)
 		return

--- a/update.go
+++ b/update.go
@@ -41,5 +41,9 @@ func updateHandler(c *gin.Context) {
 		return
 	}
 	c.JSON(200, gin.H{"success": "Please wait a moment while the agent reboots itself"})
-	Systray.RestartWith(restartPath)
+	if restartPath == "quit" {
+		Systray.Quit()
+	} else {
+		Systray.RestartWith(restartPath)
+	}
 }

--- a/update.go
+++ b/update.go
@@ -35,7 +35,7 @@ import (
 )
 
 func updateHandler(c *gin.Context) {
-	restartPath, err := updater.CheckForUpdates(version, *updateURL, *updateURL, *appName)
+	restartPath, err := updater.CheckForUpdates(version, *updateURL, *appName)
 	if err != nil {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -22,7 +22,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -76,4 +79,34 @@ func fetch(url string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("bad http status from %s: %v", url, resp.Status)
 	}
 	return resp.Body, nil
+}
+
+// addTempSuffixToPath adds the "-temp" suffix to the path to an executable file (a ".exe" extension is replaced with "-temp.exe")
+func addTempSuffixToPath(path string) string {
+	if filepath.Ext(path) == "exe" {
+		path = strings.Replace(path, ".exe", "-temp.exe", -1)
+	} else {
+		path = path + "-temp"
+	}
+
+	return path
+}
+
+// removeTempSuffixFromPath removes "-temp" suffix from the path to an executable file (a "-temp.exe" extension is replaced with ".exe")
+func removeTempSuffixFromPath(path string) string {
+	return strings.Replace(path, "-temp", "", -1)
+}
+
+func copyExe(from, to string) error {
+	data, err := os.ReadFile(from)
+	if err != nil {
+		log.Println("Cannot read file: ", from)
+		return err
+	}
+	err = os.WriteFile(to, data, 0755)
+	if err != nil {
+		log.Println("Cannot write file: ", to)
+		return err
+	}
+	return nil
 }

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -36,8 +36,8 @@ func Start(src string) string {
 
 // CheckForUpdates checks if there is a new version of the binary available and
 // if so downloads it.
-func CheckForUpdates(currentVersion string, updateAPIURL, updateBinURL string, cmdName string) (string, error) {
-	return checkForUpdates(currentVersion, updateAPIURL, updateBinURL, cmdName)
+func CheckForUpdates(currentVersion string, updateURL string, cmdName string) (string, error) {
+	return checkForUpdates(currentVersion, updateURL, cmdName)
 }
 
 const (

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -44,8 +44,8 @@ const (
 	plat = runtime.GOOS + "-" + runtime.GOARCH
 )
 
-func fetchInfo(updateAPIURL string, cmdName string) (*availableUpdateInfo, error) {
-	r, err := fetch(updateAPIURL + cmdName + "/" + plat + ".json")
+func fetchInfo(updateAPIURL string) (*availableUpdateInfo, error) {
+	r, err := fetch(updateAPIURL)
 	if err != nil {
 		return nil, err
 	}

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -15,10 +15,105 @@
 
 package updater
 
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/arduino/go-paths-helper"
+	"github.com/codeclysm/extract/v3"
+)
+
 func start(src string) string {
 	return ""
 }
 
 func checkForUpdates(currentVersion string, updateAPIURL, updateBinURL string, cmdName string) (string, error) {
-	return "", nil
+	executablePath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("could not app path: %w", err)
+	}
+	currentAppPath := paths.New(executablePath).Parent().Parent().Parent()
+	if currentAppPath.Ext() != ".app" {
+		return "", fmt.Errorf("could not find app root in %s", executablePath)
+	}
+	oldAppPath := currentAppPath.Parent().Join("ArdiunoCreateAgent.old.app")
+	if oldAppPath.Exist() {
+		return "", fmt.Errorf("temp app already exists: %s, cannot update", oldAppPath)
+	}
+
+	// Fetch information about updates
+	info, err := fetchInfo(updateAPIURL, cmdName)
+	if err != nil {
+		return "", err
+	}
+	if info.Version == currentVersion {
+		// No updates available, bye bye
+		return "", nil
+	}
+
+	tmp := paths.TempDir().Join("arduino-create-agent")
+	tmpZip := tmp.Join("update.zip")
+	tmpAppPath := tmp.Join("ArduinoCreateAgent-update.app")
+	defer tmp.RemoveAll()
+
+	// Download the update.
+	download, err := fetch(updateBinURL + cmdName + "/" + plat + "/" + info.Version + "/" + cmdName)
+	if err != nil {
+		return "", err
+	}
+	defer download.Close()
+
+	f, err := tmpZip.Create()
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	sha := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(sha, f), download); err != nil {
+		return "", err
+	}
+	f.Close()
+
+	// Check the hash
+	if s := sha.Sum(nil); !bytes.Equal(s, info.Sha256) {
+		return "", fmt.Errorf("bad hash: %s (expected %s)", s, info.Sha256)
+	}
+
+	// Unzip the update
+	if err := tmpAppPath.MkdirAll(); err != nil {
+		return "", fmt.Errorf("could not create tmp dir to unzip update: %w", err)
+	}
+
+	f, err = tmpZip.Open()
+	if err != nil {
+		return "", fmt.Errorf("could not open archive for unzip: %w", err)
+	}
+	defer f.Close()
+	if err := extract.Archive(context.Background(), f, tmpAppPath.String(), nil); err != nil {
+		return "", fmt.Errorf("extracting archive: %w", err)
+	}
+
+	// Rename current app as .old
+	if err := currentAppPath.Rename(oldAppPath); err != nil {
+		return "", fmt.Errorf("could not rename old app as .old: %w", err)
+	}
+
+	// Install new app
+	if err := tmpAppPath.CopyDirTo(currentAppPath); err != nil {
+		// Try rollback changes
+		_ = currentAppPath.RemoveAll()
+		_ = oldAppPath.Rename(currentAppPath)
+		return "", fmt.Errorf("could not install app: %w", err)
+	}
+
+	// Remove old app
+	_ = oldAppPath.RemoveAll()
+
+	// Restart agent
+	return currentAppPath.Join("Contents", "MacOS", "Arduino_Create_Agent").String(), nil
 }

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -15,6 +15,29 @@
 
 package updater
 
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Cocoa
+#import <Cocoa/Cocoa.h>
+
+void runApplication(const char *path) {
+	NSWorkspace *ws = [NSWorkspace sharedWorkspace];
+	NSURL *url = [NSURL fileURLWithPath:@(path) isDirectory:NO];
+
+	NSWorkspaceOpenConfiguration* configuration = [NSWorkspaceOpenConfiguration new];
+	//[configuration setEnvironment:env];
+	[configuration setPromptsUserIfNeeded:YES];
+	[configuration setCreatesNewApplicationInstance:YES];
+
+	dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+	[ws openApplicationAtURL:url configuration:configuration completionHandler:^(NSRunningApplication* app, NSError* error) {
+		dispatch_semaphore_signal(semaphore);
+	}];
+	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+}
+*/
+import "C"
+
 import (
 	"bytes"
 	"context"
@@ -125,7 +148,9 @@ func checkForUpdates(currentVersion string, updateAPIURL, updateBinURL string, c
 	_ = oldAppPath.RemoveAll()
 
 	// Restart agent
-	newExecutable := currentAppPath.Join("Contents", "MacOS", "Arduino_Create_Agent")
-	logrus.WithField("path", newExecutable).Info("Running new app")
-	return newExecutable.String(), nil
+	logrus.WithField("path", currentAppPath).Info("Running new app")
+	C.runApplication(C.CString(currentAppPath.String()))
+
+	// Close old agent
+	return "quit", nil
 }

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -46,13 +46,30 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/arduino/go-paths-helper"
 	"github.com/codeclysm/extract/v3"
 	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func start(src string) string {
+	if strings.Contains(src, "-temp") {
+		// This is required to transition from the previous auto-update system to the new one.
+		// Updating from version <=1.2.7 will produce the `ArduinoCreateAgent-temp` file and we should
+		// complete the upgrade by copying the `ArduinoCreateAgent-temp` executable back to the original.
+		//
+		// This procedure will be automatically skipped starting from version >1.2.7.
+
+		newPath := removeTempSuffixFromPath(src)
+		if err := copyExe(src, newPath); err != nil {
+			log.Println("Copy error: ", err)
+			panic(err)
+		}
+		return newPath
+	}
+
 	return ""
 }
 

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -45,6 +45,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 
 	"github.com/arduino/go-paths-helper"
 	"github.com/codeclysm/extract/v3"
@@ -70,7 +71,13 @@ func checkForUpdates(currentVersion string, updateURL string, cmdName string) (s
 	}
 
 	// Fetch information about updates
-	info, err := fetchInfo(updateURL, cmdName)
+
+	// updateURL: "https://downloads.arduino.cc/"
+	// cmdName: "CreateAgent/Stable"
+	// plat: "darwin-amd64"
+	// info URL: "https://downloads.arduino.cc/CreateAgent/Stable/darwin-amd64-bundle.json"
+	infoURL := updateURL + cmdName + "/" + plat + "-bundle.json"
+	info, err := fetchInfo(infoURL)
 	if err != nil {
 		return "", err
 	}
@@ -88,7 +95,13 @@ func checkForUpdates(currentVersion string, updateURL string, cmdName string) (s
 	defer tmp.RemoveAll()
 
 	// Download the update.
-	downloadURL := updateURL + cmdName + "/" + info.Version + "/ArduinoCreateAgent.app_notarized.zip"
+
+	// updateURL: "https://downloads.arduino.cc/"
+	// cmdName == "CreateAgent/Stable"
+	// info.Version == "1.2.8"
+	// runtime.GOARCH: "amd64"
+	// downloadURL: "https://downloads.arduino.cc/CreateAgent/Stable/1.2.8/ArduinoCreateAgent.app_arm64_notarized.zip"
+	downloadURL := updateURL + cmdName + "/" + info.Version + "/ArduinoCreateAgent.app_" + runtime.GOARCH + "_notarized.zip"
 	logrus.WithField("url", downloadURL).Info("Downloading update")
 	download, err := fetch(downloadURL)
 	if err != nil {

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -15,29 +15,6 @@
 
 package updater
 
-/*
-#cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa
-#import <Cocoa/Cocoa.h>
-
-void runApplication(const char *path) {
-	NSWorkspace *ws = [NSWorkspace sharedWorkspace];
-	NSURL *url = [NSURL fileURLWithPath:@(path) isDirectory:NO];
-
-	NSWorkspaceOpenConfiguration* configuration = [NSWorkspaceOpenConfiguration new];
-	//[configuration setEnvironment:env];
-	[configuration setPromptsUserIfNeeded:YES];
-	[configuration setCreatesNewApplicationInstance:YES];
-
-	dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-	[ws openApplicationAtURL:url configuration:configuration completionHandler:^(NSRunningApplication* app, NSError* error) {
-		dispatch_semaphore_signal(semaphore);
-	}];
-	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-}
-*/
-import "C"
-
 import (
 	"bytes"
 	"context"
@@ -179,8 +156,7 @@ func checkForUpdates(currentVersion string, updateURL string, cmdName string) (s
 
 	// Restart agent
 	logrus.WithField("path", currentAppPath).Info("Running new app")
-	C.runApplication(C.CString(currentAppPath.String()))
 
 	// Close old agent
-	return "quit", nil
+	return currentAppPath.String(), nil
 }

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -55,7 +55,7 @@ func start(src string) string {
 	return ""
 }
 
-func checkForUpdates(currentVersion string, updateAPIURL, updateBinURL string, cmdName string) (string, error) {
+func checkForUpdates(currentVersion string, updateURL string, cmdName string) (string, error) {
 	executablePath, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("could not app path: %w", err)
@@ -70,7 +70,7 @@ func checkForUpdates(currentVersion string, updateAPIURL, updateBinURL string, c
 	}
 
 	// Fetch information about updates
-	info, err := fetchInfo(updateAPIURL, cmdName)
+	info, err := fetchInfo(updateURL, cmdName)
 	if err != nil {
 		return "", err
 	}
@@ -88,7 +88,7 @@ func checkForUpdates(currentVersion string, updateAPIURL, updateBinURL string, c
 	defer tmp.RemoveAll()
 
 	// Download the update.
-	downloadURL := updateBinURL + cmdName + "/" + info.Version + "/ArduinoCreateAgent.app_notarized.zip"
+	downloadURL := updateURL + cmdName + "/" + info.Version + "/ArduinoCreateAgent.app_notarized.zip"
 	logrus.WithField("url", downloadURL).Info("Downloading update")
 	download, err := fetch(downloadURL)
 	if err != nil {

--- a/updater/updater_default.go
+++ b/updater/updater_default.go
@@ -225,7 +225,8 @@ func (u *Updater) update() error {
 	}
 	defer old.Close()
 
-	info, err := fetchInfo(u.UpdateURL, u.CmdName)
+	infoURL := u.UpdateURL + u.CmdName + "/" + plat + ".json"
+	info, err := fetchInfo(infoURL)
 	if err != nil {
 		log.Println(err)
 		return err

--- a/updater/updater_default.go
+++ b/updater/updater_default.go
@@ -97,36 +97,6 @@ func checkForUpdates(currentVersion string, updateURL string, cmdName string) (s
 	return addTempSuffixToPath(path), nil
 }
 
-func copyExe(from, to string) error {
-	data, err := os.ReadFile(from)
-	if err != nil {
-		log.Println("Cannot read file: ", from)
-		return err
-	}
-	err = os.WriteFile(to, data, 0755)
-	if err != nil {
-		log.Println("Cannot write file: ", to)
-		return err
-	}
-	return nil
-}
-
-// addTempSuffixToPath adds the "-temp" suffix to the path to an executable file (a ".exe" extension is replaced with "-temp.exe")
-func addTempSuffixToPath(path string) string {
-	if filepath.Ext(path) == "exe" {
-		path = strings.Replace(path, ".exe", "-temp.exe", -1)
-	} else {
-		path = path + "-temp"
-	}
-
-	return path
-}
-
-// removeTempSuffixFromPath removes "-temp" suffix from the path to an executable file (a "-temp.exe" extension is replaced with ".exe")
-func removeTempSuffixFromPath(path string) string {
-	return strings.Replace(path, "-temp", "", -1)
-}
-
 // Updater is the configuration and runtime data for doing an update.
 //
 // Note that ApiURL, BinURL and DiffURL should have the same value if all files are available at the same location.

--- a/updater/updater_default.go
+++ b/updater/updater_default.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kr/binarydist"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/inconshreveable/go-update.v0"
 )
@@ -60,7 +59,6 @@ import (
 //
 
 var errHashMismatch = errors.New("new file hash mismatch after patch")
-var errDiffURLUndefined = errors.New("DiffURL is not defined, I cannot fetch and apply patch, reverting to full bin")
 var up = update.New()
 
 func start(src string) string {
@@ -81,16 +79,14 @@ func start(src string) string {
 	return ""
 }
 
-func checkForUpdates(currentVersion string, updateAPIURL, updateBinURL string, cmdName string) (string, error) {
+func checkForUpdates(currentVersion string, updateURL string, cmdName string) (string, error) {
 	path, err := os.Executable()
 	if err != nil {
 		return "", err
 	}
 	var up = &Updater{
 		CurrentVersion: currentVersion,
-		APIURL:         updateAPIURL,
-		BinURL:         updateBinURL,
-		DiffURL:        "",
+		UpdateURL:      updateURL,
 		Dir:            "update/",
 		CmdName:        cmdName,
 	}
@@ -139,9 +135,7 @@ func removeTempSuffixFromPath(path string) string {
 //
 //	updater := &selfupdate.Updater{
 //		CurrentVersion: version,
-//		ApiURL:         "http://updates.yourdomain.com/",
-//		BinURL:         "http://updates.yourdownmain.com/",
-//		DiffURL:        "http://updates.yourdomain.com/",
+//		UpdateURL:      "http://updates.yourdomain.com/",
 //		Dir:            "update/",
 //		CmdName:        "myapp", // app name
 //	}
@@ -150,10 +144,8 @@ func removeTempSuffixFromPath(path string) string {
 //	}
 type Updater struct {
 	CurrentVersion string               // Currently running version.
-	APIURL         string               // Base URL for API requests (json files).
+	UpdateURL      string               // Base URL for API requests (json files).
 	CmdName        string               // Command name is appended to the ApiURL like http://apiurl/CmdName/. This represents one binary.
-	BinURL         string               // Base URL for full binary downloads.
-	DiffURL        string               // Base URL for diff downloads.
 	Dir            string               // Directory to store selfupdate state.
 	Info           *availableUpdateInfo // Information about the available update.
 }
@@ -183,31 +175,6 @@ func verifySha(bin []byte, sha []byte) bool {
 	return bytes.Equal(h.Sum(nil), sha)
 }
 
-func (u *Updater) fetchAndApplyPatch(old io.Reader) ([]byte, error) {
-	if u.DiffURL == "" {
-		return nil, errDiffURLUndefined
-	}
-	r, err := fetch(u.DiffURL + u.CmdName + "/" + u.CurrentVersion + "/" + u.Info.Version + "/" + plat)
-	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	var buf bytes.Buffer
-	err = binarydist.Patch(old, &buf, r)
-	return buf.Bytes(), err
-}
-
-func (u *Updater) fetchAndVerifyPatch(old io.Reader) ([]byte, error) {
-	bin, err := u.fetchAndApplyPatch(old)
-	if err != nil {
-		return nil, err
-	}
-	if !verifySha(bin, u.Info.Sha256) {
-		return nil, errHashMismatch
-	}
-	return bin, nil
-}
-
 func (u *Updater) fetchAndVerifyFullBin() ([]byte, error) {
 	bin, err := u.fetchBin()
 	if err != nil {
@@ -221,7 +188,7 @@ func (u *Updater) fetchAndVerifyFullBin() ([]byte, error) {
 }
 
 func (u *Updater) fetchBin() ([]byte, error) {
-	r, err := fetch(u.BinURL + u.CmdName + "/" + u.Info.Version + "/" + plat + ".gz")
+	r, err := fetch(u.UpdateURL + u.CmdName + "/" + u.Info.Version + "/" + plat + ".gz")
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +225,7 @@ func (u *Updater) update() error {
 	}
 	defer old.Close()
 
-	info, err := fetchInfo(u.APIURL, u.CmdName)
+	info, err := fetchInfo(u.UpdateURL, u.CmdName)
 	if err != nil {
 		log.Println(err)
 		return err
@@ -267,26 +234,15 @@ func (u *Updater) update() error {
 	if u.Info.Version == u.CurrentVersion {
 		return nil
 	}
-	bin, err := u.fetchAndVerifyPatch(old)
-	if err != nil {
-		switch err {
-		case errHashMismatch:
-			log.Println("update: hash mismatch from patched binary")
-		case errDiffURLUndefined:
-			log.Println("update: ", err)
-		default:
-			log.Println("update: patching binary, ", err)
-		}
 
-		bin, err = u.fetchAndVerifyFullBin()
-		if err != nil {
-			if err == errHashMismatch {
-				log.Println("update: hash mismatch from full binary")
-			} else {
-				log.Println("update: fetching full binary,", err)
-			}
-			return err
+	bin, err := u.fetchAndVerifyFullBin()
+	if err != nil {
+		if err == errHashMismatch {
+			log.Println("update: hash mismatch from full binary")
+		} else {
+			log.Println("update: fetching full binary,", err)
 		}
+		return err
 	}
 
 	// close the old binary before installing because on windows


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
Implements a new auto-update procedure to handle the new security features of MacOS Ventura.

- **What is the current behavior?**
The old auto-update replaces the Agent executable binary in place, this method does not work anymore because it breaks MacOS Ventura checks for the application's signature.

* **What is the new behavior?**
The new auto-update method replaces the whole `.app` folder.
It also uses the MacOS Cocoa SDK function `openApplicationAtURL:url` to restart the app after the upgrade.

- **Does this PR introduce a breaking change?**
No

* **Other information**:
