### PR TITLE
Check the folder content in new version of the agent on macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,7 +572,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: ${{ steps.release_body.outputs.RBODY}}
           draft: false
-          prerelease: true
+          prerelease: ${{ needs.build.outputs.prerelease }}
 
       - name: Upload release files on Github
         uses: svenstaro/upload-release-action@v2
@@ -586,8 +586,8 @@ jobs:
         run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
         if: ${{ needs.build.outputs.prerelease != 'true' }}
 
-      # - name: Update version file (used by frontend to trigger autoupdate and create filename)
-      #   run: |
-      #     echo {\"Version\": \"${GITHUB_REF##*/}\"} > /tmp/agent-version.json
-      #     aws s3 cp /tmp/agent-version.json s3://${{ env.VERSION_TARGET }}
-      #   if: ${{ needs.build.outputs.prerelease != 'true' }}
+      - name: Update version file (used by frontend to trigger autoupdate and create filename)
+        run: |
+          echo {\"Version\": \"${GITHUB_REF##*/}\"} > /tmp/agent-version.json
+          aws s3 cp /tmp/agent-version.json s3://${{ env.VERSION_TARGET }}
+        if: ${{ needs.build.outputs.prerelease != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,7 +572,7 @@ jobs:
           release_name: ${{ github.ref }}
           body: ${{ steps.release_body.outputs.RBODY}}
           draft: false
-          prerelease: ${{ needs.build.outputs.prerelease }}
+          prerelease: true
 
       - name: Upload release files on Github
         uses: svenstaro/upload-release-action@v2
@@ -586,8 +586,8 @@ jobs:
         run: aws s3 sync release/ s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}
         if: ${{ needs.build.outputs.prerelease != 'true' }}
 
-      - name: Update version file (used by frontend to trigger autoupdate and create filename)
-        run: |
-          echo {\"Version\": \"${GITHUB_REF##*/}\"} > /tmp/agent-version.json
-          aws s3 cp /tmp/agent-version.json s3://${{ env.VERSION_TARGET }}
-        if: ${{ needs.build.outputs.prerelease != 'true' }}
+      # - name: Update version file (used by frontend to trigger autoupdate and create filename)
+      #   run: |
+      #     echo {\"Version\": \"${GITHUB_REF##*/}\"} > /tmp/agent-version.json
+      #     aws s3 cp /tmp/agent-version.json s3://${{ env.VERSION_TARGET }}
+      #   if: ${{ needs.build.outputs.prerelease != 'true' }}

--- a/main.go
+++ b/main.go
@@ -453,7 +453,7 @@ func oldInstallExists() bool {
 	if binIsOld {
 		return false
 	}
-	return oldAgentPath.Exist()
+	return oldAgentPath.Join("ArduinoCreateAgent.app").Exist()
 }
 
 // printDialog will print a GUI error dialog on macos

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -59,7 +59,7 @@ func checkForUpdates(currentVersion string, updateURL string, cmdName string) (s
 	if currentAppPath.Ext() != ".app" {
 		return "", fmt.Errorf("could not find app root in %s", executablePath)
 	}
-	oldAppPath := currentAppPath.Parent().Join("ArdiunoCreateAgent.old.app")
+	oldAppPath := currentAppPath.Parent().Join("ArduinoCreateAgent.old.app")
 	if oldAppPath.Exist() {
 		return "", fmt.Errorf("temp app already exists: %s, cannot update", oldAppPath)
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
bug fix

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
when uninstalling an old version of the agent (e.g. 1.2.7) a folder in `~/Applications/ArduinoCreateAgent` could be left behind (empty, but existing), after uninstalling.
This will trigger this error when running a new agent:

![image](https://github.com/arduino/arduino-create-agent/assets/34278123/32f89e1f-e6a2-47d4-b531-e4be07191b17)

* **What is the new behavior?**
<!-- if this is a feature change -->

The check in the new agent is performed on the existence of the `ArduinoCreateAgent.app` subfolder.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
Partially fixes #795 
