### PR TITLE
Fix https certificates being removed after `downloadtool` command

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -26,9 +26,6 @@ import (
 	"strconv"
 	"strings"
 
-	cert "github.com/arduino/arduino-create-agent/certificates"
-	"github.com/arduino/arduino-create-agent/config"
-
 	"github.com/arduino/arduino-create-agent/upload"
 	log "github.com/sirupsen/logrus"
 )
@@ -183,9 +180,6 @@ func checkCmd(m []byte) {
 		go spList(false)
 		go spList(true)
 	} else if strings.HasPrefix(sl, "downloadtool") {
-		// Always delete root certificates when we receive a downloadtool command
-		// Useful if the install procedure was not followed strictly (eg. manually)
-		cert.DeleteCertificates(config.GetCertificatesDir())
 		go func() {
 			args := strings.Split(s, " ")
 			var tool, toolVersion, pack, behaviour string

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -101,6 +101,7 @@ func (s *Systray) start() {
 				err := cert.InstallCertificate(certDir.Join("ca.cert.cer"))
 				// if something goes wrong during the cert install we remove them, so the user is able to retry
 				if err != nil {
+					log.Errorf("cannot install certificates something went wrong: %s", err)
 					cert.DeleteCertificates(certDir)
 				}
 				s.Restart()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
When the frontend connects to the agent a command is sent to download the required tools (for flashing/fwupload etc...). This command `downloadtool` had a strange behavior: It used to remove the certificates in the user dir.
* **What is the new behavior?**
<!-- if this is a feature change -->
 This has been removed since it's no longer necessary
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
