### PR TITLE
Create `LaunchAgents/` directory if it doesn't exist (MacOS)

### DIFF
--- a/config/autostart.go
+++ b/config/autostart.go
@@ -31,7 +31,15 @@ var launchdAgentDefinition []byte
 
 // getLaunchdAgentPath will return the path of the launchd agent default path
 func getLaunchdAgentPath() *paths.Path {
-	return GetDefaultHomeDir().Join("Library", "LaunchAgents", "ArduinoCreateAgent.plist")
+	homeDir := GetDefaultHomeDir()
+	launchAgentsPath := homeDir.Join("Library", "LaunchAgents")
+	agentPlistPath := launchAgentsPath.Join("ArduinoCreateAgent.plist")
+
+	if err := os.MkdirAll(launchAgentsPath.String(), 0755); err != nil {
+		log.Panicf("Could not create ~/Library/LaunchAgents directory: %s", err)
+	}
+
+	return agentPlistPath
 }
 
 // InstallPlistFile will handle the process of creating the plist file required for the autostart


### PR DESCRIPTION
- [x] The PR has no duplicates
- [ ] Tests for the changes have been added (for bug fixes / features)
  - It didn't look like there were any tests for the config module—if I missed it, though, let me know! (Adding a whole test file for `config` at this time felt a bit out of scope imo) Happy to add them in another place though!

In the meantime, here's a quick Gist you can run to test out the changes locally: https://gist.github.com/xplato/ff85973647e9a1b5190361e331c27fe0

* **What kind of change does this PR introduce?**
This is a bug fix in the `config` module. On MacOS, sometimes the `~/Library/LaunchAgents/` directory does not exist—if not, this would cause the program to not start because the path to the config file would be invalid (see the end of this PR description for the relevant log/info). This will create the directory if it doesn't exist, allowing the program to run correctly.

- **What is the current behavior?**
If the `~/Library/LaunchAgents` directory doesn't exist, the program will not start.

* **What is the new behavior?**
Updates the `getLaunchdAgentPath` function to create the `~/Library/LaunchAgents` directory if it doesn't exist, returning the path as usual.

- **Does this PR introduce a breaking change?**
No (depends on how you look at it I guess 😅).

* **Other information**:
The only way I found to catch this is by deleting the `~/Library/LaunchAgents` directory and running the binary manually via `ArduinoCreateAgent.app` -> "Show package contents" -> `Contents/MacOS/Arduino_Create_Agent`

The relevant log:

`ERRO[0000] open /Users/$USER/Library/LaunchAgents/ArduinoCreateAgent.plist: no such file or directory`
