### PR TITLE
Remove io/ioutil since is deprecated

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -28,7 +28,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -134,7 +133,7 @@ func uploadHandler(c *gin.Context) {
 	var filePaths []string
 	filePaths = append(filePaths, filePath)
 
-	tmpdir, err := ioutil.TempDir("", "extrafiles")
+	tmpdir, err := os.MkdirTemp("", "extrafiles")
 	if err != nil {
 		c.String(http.StatusBadRequest, err.Error())
 		return
@@ -151,7 +150,7 @@ func uploadHandler(c *gin.Context) {
 			return
 		}
 
-		err := ioutil.WriteFile(path, extraFile.Hex, 0644)
+		err := os.WriteFile(path, extraFile.Hex, 0644)
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())
 			return

--- a/tools/download.go
+++ b/tools/download.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -125,7 +124,7 @@ func (t *Tools) DownloadPackageIndex(indexFile, signatureFile string) error {
 	defer resp.Body.Close()
 
 	// Read the body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -138,12 +137,12 @@ func (t *Tools) DownloadPackageIndex(indexFile, signatureFile string) error {
 	defer signature.Body.Close()
 
 	// Read the body
-	signatureBody, err := ioutil.ReadAll(signature.Body)
+	signatureBody, err := io.ReadAll(signature.Body)
 	if err != nil {
 		return err
 	}
-	ioutil.WriteFile(indexFile, body, 0644)
-	ioutil.WriteFile(signatureFile, signatureBody, 0644)
+	os.WriteFile(indexFile, body, 0644)
+	os.WriteFile(signatureFile, signatureBody, 0644)
 
 	t.LastRefresh = time.Now()
 
@@ -194,7 +193,7 @@ func (t *Tools) Download(pack, name, version, behaviour string) error {
 		return err
 	}
 
-	body, err := ioutil.ReadFile(indexFile)
+	body, err := os.ReadFile(indexFile)
 	if err != nil {
 		return err
 	}
@@ -236,7 +235,7 @@ func (t *Tools) Download(pack, name, version, behaviour string) error {
 	defer resp.Body.Close()
 
 	// Read the body
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/tools/download_test.go
+++ b/tools/download_test.go
@@ -18,7 +18,7 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -104,7 +104,7 @@ func TestTools_DownloadAndUnpackBehaviour(t *testing.T) {
 	}
 	expectedDirList := []string{"bin", "etc"}
 
-	tmpDir, err := ioutil.TempDir("", "download_test")
+	tmpDir, err := os.MkdirTemp("", "download_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestTools_DownloadAndUnpackBehaviour(t *testing.T) {
 		defer resp.Body.Close()
 
 		// Read the body
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("%v", err)
 		}
@@ -148,7 +148,7 @@ func TestTools_DownloadAndUnpackBehaviour(t *testing.T) {
 		default:
 			t.Errorf("no suitable type found")
 		}
-		files, err := ioutil.ReadDir(location)
+		files, err := os.ReadDir(location)
 		if err != nil {
 			t.Errorf("%v", err)
 		}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -18,7 +18,6 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -125,7 +124,7 @@ func (t *Tools) writeMap() error {
 		return err
 	}
 	filePath := path.Join(dir(), "installed.json")
-	return ioutil.WriteFile(filePath, b, 0644)
+	return os.WriteFile(filePath, b, 0644)
 }
 
 // readMap() reads the installed map from json file "installed.json"
@@ -133,7 +132,7 @@ func (t *Tools) readMap() error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	filePath := path.Join(dir(), "installed.json")
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}

--- a/upload/upload.go
+++ b/upload/upload.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -301,7 +300,7 @@ func form(port, board, file string, auth Auth, l Logger) error {
 
 	// Check the response
 	if res.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		return errors.New("Request error:" + string(body))
 	}
 	return nil

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -35,7 +34,7 @@ import (
 // Note that path could be defined and still there could be an error.
 func SaveFileonTempDir(filename string, data io.Reader) (path string, err error) {
 	// Create Temp Directory
-	tmpdir, err := ioutil.TempDir("", "arduino-create-agent")
+	tmpdir, err := os.MkdirTemp("", "arduino-create-agent")
 	if err != nil {
 		return "", errors.New("Could not create temp directory to store downloaded file. Do you have permissions?")
 	}

--- a/v2/pkgs/indexes.go
+++ b/v2/pkgs/indexes.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"encoding/json"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -71,7 +70,7 @@ func (c *Indexes) Add(ctx context.Context, payload *indexes.IndexPayload) (*inde
 func (c *Indexes) Get(ctx context.Context, uri string) (index Index, err error) {
 	filename := b64.StdEncoding.EncodeToString([]byte(url.PathEscape(uri)))
 	path := filepath.Join(c.Folder, filename)
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return index, err
 	}
@@ -89,7 +88,7 @@ func (c *Indexes) List(context.Context) ([]string, error) {
 	// Create folder if it doesn't exist
 	_ = os.MkdirAll(c.Folder, 0755)
 	// Read files
-	files, err := ioutil.ReadDir(c.Folder)
+	files, err := os.ReadDir(c.Folder)
 
 	if err != nil {
 		return nil, err

--- a/v2/pkgs/indexes_test.go
+++ b/v2/pkgs/indexes_test.go
@@ -17,7 +17,6 @@ package pkgs_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -38,7 +37,7 @@ func TestIndexes(t *testing.T) {
 	defer ts.Close()
 
 	// Initialize indexes with a temp folder
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v2/pkgs/tools.go
+++ b/v2/pkgs/tools.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -89,7 +88,7 @@ func (c *Tools) Installed(ctx context.Context) (tools.ToolCollection, error) {
 	res := tools.ToolCollection{}
 
 	// Find packagers
-	packagers, err := ioutil.ReadDir(c.Folder)
+	packagers, err := os.ReadDir(c.Folder)
 	if err != nil {
 		if !strings.Contains(err.Error(), "no such file") {
 			return nil, err
@@ -106,7 +105,7 @@ func (c *Tools) Installed(ctx context.Context) (tools.ToolCollection, error) {
 		}
 
 		// Find tools
-		toolss, err := ioutil.ReadDir(filepath.Join(c.Folder, packager.Name()))
+		toolss, err := os.ReadDir(filepath.Join(c.Folder, packager.Name()))
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +113,7 @@ func (c *Tools) Installed(ctx context.Context) (tools.ToolCollection, error) {
 		for _, tool := range toolss {
 			// Find versions
 			path := filepath.Join(c.Folder, packager.Name(), tool.Name())
-			versions, err := ioutil.ReadDir(path)
+			versions, err := os.ReadDir(path)
 			if err != nil {
 				continue // we ignore errors because the folders could be dirty
 			}
@@ -264,7 +263,7 @@ func writeInstalled(folder, path string) error {
 	// read installed.json
 	installed := map[string]string{}
 
-	data, err := ioutil.ReadFile(filepath.Join(folder, "installed.json"))
+	data, err := os.ReadFile(filepath.Join(folder, "installed.json"))
 	if err == nil {
 		err = json.Unmarshal(data, &installed)
 		if err != nil {
@@ -283,5 +282,5 @@ func writeInstalled(folder, path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(folder, "installed.json"), data, 0644)
+	return os.WriteFile(filepath.Join(folder, "installed.json"), data, 0644)
 }

--- a/v2/pkgs/tools_test.go
+++ b/v2/pkgs/tools_test.go
@@ -17,7 +17,6 @@ package pkgs_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,7 +39,7 @@ func TestTools(t *testing.T) {
 	defer ts.Close()
 
 	// Initialize indexes with a temp folder
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
remove [deprecated package](https://pkg.go.dev/io/ioutil)
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.
* **What is the new behavior?**
<!-- if this is a feature change -->
We use package io or os
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
