### PR TITLE
Use SafeJoin in V2 Tools Install endpoint

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -98,26 +98,36 @@ func TestInstallToolV2(t *testing.T) {
 		responseBody string
 	}
 
-	BossacURL := "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linux64.tar.gz"
-	BossacChecksum := "SHA-256:1ae54999c1f97234a5c603eb99ad39313b11746a4ca517269a9285afa05f9100"
-	BossacSignature := "382898a97b5a86edd74208f10107d2fecbf7059ffe9cc856e045266fb4db4e98802728a0859cfdcda1c0b9075ec01e42dbea1f430b813530d5a6ae1766dfbba64c3e689b59758062dc2ab2e32b2a3491dc2b9a80b9cda4ae514fbe0ec5af210111b6896976053ab76bac55bcecfcececa68adfa3299e3cde6b7f117b3552a7d80ca419374bb497e3c3f12b640cf5b20875416b45e662fc6150b99b178f8e41d6982b4c0a255925ea39773683f9aa9201dc5768b6fc857c87ff602b6a93452a541b8ec10ca07f166e61a9e9d91f0a6090bd2038ed4427af6251039fb9fe8eb62ec30d7b0f3df38bc9de7204dec478fb86f8eb3f71543710790ee169dce039d3e0"
+	bossacURL := "http://downloads.arduino.cc/tools/bossac-1.7.0-arduino3-linux64.tar.gz"
+	bossacChecksum := "SHA-256:1ae54999c1f97234a5c603eb99ad39313b11746a4ca517269a9285afa05f9100"
+	bossacSignature := "382898a97b5a86edd74208f10107d2fecbf7059ffe9cc856e045266fb4db4e98802728a0859cfdcda1c0b9075ec01e42dbea1f430b813530d5a6ae1766dfbba64c3e689b59758062dc2ab2e32b2a3491dc2b9a80b9cda4ae514fbe0ec5af210111b6896976053ab76bac55bcecfcececa68adfa3299e3cde6b7f117b3552a7d80ca419374bb497e3c3f12b640cf5b20875416b45e662fc6150b99b178f8e41d6982b4c0a255925ea39773683f9aa9201dc5768b6fc857c87ff602b6a93452a541b8ec10ca07f166e61a9e9d91f0a6090bd2038ed4427af6251039fb9fe8eb62ec30d7b0f3df38bc9de7204dec478fb86f8eb3f71543710790ee169dce039d3e0"
 	bossacInstallURLOK := tools.ToolPayload{
 		Name:      "bossac",
 		Version:   "1.7.0-arduino3",
 		Packager:  "arduino",
-		URL:       &BossacURL,
-		Checksum:  &BossacChecksum,
-		Signature: &BossacSignature,
+		URL:       &bossacURL,
+		Checksum:  &bossacChecksum,
+		Signature: &bossacSignature,
 	}
 
-	WrongSignature := "wr0ngs1gn4tur3"
+	wrongSignature := "wr0ngs1gn4tur3"
 	bossacInstallWrongSig := tools.ToolPayload{
 		Name:      "bossac",
 		Version:   "1.7.0-arduino3",
 		Packager:  "arduino",
-		URL:       &BossacURL,
-		Checksum:  &BossacChecksum,
-		Signature: &WrongSignature,
+		URL:       &bossacURL,
+		Checksum:  &bossacChecksum,
+		Signature: &wrongSignature,
+	}
+
+	wrongChecksum := "wr0ngch3cksum"
+	bossacInstallWrongCheck := tools.ToolPayload{
+		Name:      "bossac",
+		Version:   "1.7.0-arduino3",
+		Packager:  "arduino",
+		URL:       &bossacURL,
+		Checksum:  &wrongChecksum,
+		Signature: &bossacSignature,
 	}
 
 	bossacInstallNoURL := tools.ToolPayload{
@@ -129,6 +139,7 @@ func TestInstallToolV2(t *testing.T) {
 	tests := []test{
 		{bossacInstallURLOK, http.StatusOK, "ok"},
 		{bossacInstallWrongSig, http.StatusInternalServerError, "verification error"},
+		{bossacInstallWrongCheck, http.StatusInternalServerError, "checksum doesn't match"},
 		{bossacInstallNoURL, http.StatusBadRequest, "tool not found"}, //because the index is not added
 	}
 

--- a/v2/pkgs/tools_test.go
+++ b/v2/pkgs/tools_test.go
@@ -132,26 +132,6 @@ func TestTools(t *testing.T) {
 		t.Fatalf("expected %d == %d (%s)", len(installed), 0, "len(installed)")
 	}
 
-	// Install a tool by specifying url and checksum
-	_, err = service.Install(ctx, &tools.ToolPayload{
-		Packager: "arduino",
-		Name:     "avrdude",
-		Version:  "6.0.1-arduino2",
-		URL:      strpoint(url()),
-		Checksum: strpoint(checksum()),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	installed, err = service.Installed(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(installed) != 1 {
-		t.Fatalf("expected %d == %d (%s)", len(installed), 1, "len(installed)")
-	}
-
 	t.Run("payload containing evil names", func(t *testing.T) {
 		evilFileNames := []string{
 			"/",
@@ -182,28 +162,4 @@ func TestTools(t *testing.T) {
 
 func strpoint(s string) *string {
 	return &s
-}
-
-func url() string {
-	urls := map[string]string{
-		"linuxamd64":   "https://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-x86_64-pc-linux-gnu.tar.bz2",
-		"linux386":     "https://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i686-pc-linux-gnu.tar.bz2",
-		"darwinamd64":  "https://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i386-apple-darwin11.tar.bz2",
-		"windows386":   "https://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i686-mingw32.zip",
-		"windowsamd64": "https://downloads.arduino.cc/tools/avrdude-6.0.1-arduino2-i686-mingw32.zip",
-	}
-
-	return urls[runtime.GOOS+runtime.GOARCH]
-}
-
-func checksum() string {
-	checksums := map[string]string{
-		"linuxamd64":   "SHA-256:2489004d1d98177eaf69796760451f89224007c98b39ebb5577a9a34f51425f1",
-		"linux386":     "SHA-256:6f633dd6270ad0d9ef19507bcbf8697b414a15208e4c0f71deec25ef89cdef3f",
-		"darwinamd64":  "SHA-256:71117cce0096dad6c091e2c34eb0b9a3386d3aec7d863d2da733d9e5eac3a6b1",
-		"windows386":   "SHA-256:6c5483800ba753c80893607e30cade8ab77b182808fcc5ea15fa3019c63d76ae",
-		"windowsamd64": "SHA-256:6c5483800ba753c80893607e30cade8ab77b182808fcc5ea15fa3019c63d76ae",
-	}
-	return checksums[runtime.GOOS+runtime.GOARCH]
-
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [X] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Security Fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The v2 install endpoint is vulnerable to path traversal vulnerability
* **What is the new behavior?**
<!-- if this is a feature change -->
That is fixed (leveraging the `SafeJoin` function introduced in #821)
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
