### PR TITLE
fix agent being built for 32 bit linux for real

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -394,7 +394,11 @@ jobs:
         # installbuilder reads the env vars with certs paths and use it to sign the installer.
       - name: Launch Bitrock installbuilder
         run: |
-          ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.platform-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} architecture=${{ matrix.arch }}
+          if [[ ${{matrix.platform-name}} == "linux" ]]; then
+            ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.platform-name }}-x64 --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} architecture=${{ matrix.arch }}
+          else
+            ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.platform-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} architecture=${{ matrix.arch }}
+          fi
 
       - name: Generate archive
         run: tar -czvf ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.platform-name }}-${{ matrix.arch }}-installer.tar.gz ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.platform-name }}-${{ matrix.arch }}-installer${{matrix.installer-extension}}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
bugfix :lady_beetle: 
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The agent builds after 1.2.7 on linux have different kind of problems:
1. `1.3.0`, `1.3.1`, `1.3.2` are being built for linux 32 bit (see #803)
2. `1.3.3` does not contain the agent binaries (see #846)
* **What is the new behavior?**
<!-- if this is a feature change -->
I thought to have fixed #803, in the installer repo, but the regression comes from [this change](https://github.com/arduino/arduino-create-agent/commit/b62a2ff745c804f12ea1dcb6d8856602d5aa8545#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R426) (note the argument to `installbuilder` has been changed from `linux-x64` to `linux`).
This PR will
1. fix #803 once and for-all.
2. Fix #846: by generating the installer for the right platform the binaries will be included (tested locally and updated the 1.3.3 release artifacts with the manually produced ones).
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
