### PR TITLE
Replace mitchellh/go used for macOS notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ env:
   INSTALLER_CERT_MAC_PATH: "/tmp/ArduinoCerts2020.p12"
   AC_USERNAME: ${{ secrets.AC_USERNAME }} # used by gon
   AC_PASSWORD: ${{ secrets.AC_PASSWORD }} # used by gon
+  AC_PROVIDER: ${{ secrets.AC_PROVIDER }} # used by gon
   # See: https://github.com/actions/setup-go/tree/v3#readme
   GO_VERSION: "1.20"
 
@@ -261,7 +262,7 @@ jobs:
             -k "${{ env.KEYCHAIN_PASSWORD }}" \
             "${{ env.KEYCHAIN }}"
 
-      - name: Install gon for code signing and app notarization
+      - name: Install gon for code signing
         uses: actions/checkout@v4
         with:
           repository: darkvertex/gon #this fork has support for --deep notarization
@@ -288,15 +289,40 @@ jobs:
             deep = true
           }
 
-          # Ask Gon for zip output to force notarization process to take place.
-          # The CI will upload the zip output
-          zip {
-            output_path = "ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip"
-          }
           EOF
 
-      - name: Sign and notarize binary
+      - name: Sign app bundle
         run: gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
+
+      - name: Zip output app bundle
+        run: zip ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip ArduinoCreateAgent.app
+
+      - name: Remove gon used for code signing
+        run: |
+          rm /usr/local/bin/gon
+          rm ${{ env.GON_CONFIG_PATH }}
+
+      - name: Install gon for app notarization
+        run: |
+          wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
+          unzip gon_macos.zip -d /usr/local/bin
+  
+      - name: Write gon config to file
+        run: |
+          cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
+          # See: https://github.com/Bearer/gon#configuration-file
+
+          notarize {
+            path = "ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip"
+            bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
+            staple = true
+          }
+
+          EOF
+  
+      - name: Notarize app bundle
+        run: |
+          gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
 
       - name: Upload autoupdate bundle to Arduino downloads servers
         run: aws s3 cp ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip s3://${{ secrets.DOWNLOADS_BUCKET }}${{ env.TARGET }}${GITHUB_REF/refs\/tags\//}/ # the version should be created in th the build job
@@ -475,7 +501,7 @@ jobs:
 
       - name: Install gon for code signing and app notarization
         run: |
-          wget -q https://github.com/mitchellh/gon/releases/download/v0.2.5/gon_macos.zip
+          wget -q https://github.com/Bearer/gon/releases/download/v0.0.27/gon_macos.zip
           unzip gon_macos.zip -d /usr/local/bin
 
       - name: Write gon config to file
@@ -490,17 +516,13 @@ jobs:
           }
 
           # Ask Gon for zip output to force notarization process to take place.
-          # The CI will not upload the zip output
           zip {
             output_path = "ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip"
           }
           EOF
 
       - name: Code sign and notarize app
-        run: |
-          echo "gon will notarize executable in ArduinoCreateAgent-osx/ArduinoCreateAgent-${GITHUB_REF##*/}-osx-${{ matrix.arch }}-installer.dmg"
-          gon -log-level=debug -log-json gon.config_installer.hcl
-        timeout-minutes: 30
+        run: gon -log-level=debug -log-json gon.config_installer.hcl
 
       #  tar dmg file to keep executable permission
       - name: Tar files to keep permissions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,13 +455,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ArduinoCreateAgent.app_${{ matrix.arch }}_notarized
-          path: ArduinoCreateAgent.app
 
       - name: unzip artifact
-        working-directory: ArduinoCreateAgent.app
         run: |
           unzip ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip
-          rm ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip
 
       - name: Install create-dmg
         run: brew install create-dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
         run: gon -log-level=debug -log-json "${{ env.GON_CONFIG_PATH }}"
 
       - name: Zip output app bundle
-        run: zip ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip ArduinoCreateAgent.app
+        run: ditto -c -k --keepParent ArduinoCreateAgent.app/ ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip
 
       - name: Remove gon used for code signing
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,6 @@ jobs:
           notarize {
             path = "ArduinoCreateAgent.app_${{ matrix.arch }}_notarized.zip"
             bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
-            staple = true
           }
 
           EOF


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
change in tooling see https://github.com/arduino/tooling-project-assets/issues/359
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
An excellent tool named [gon](https://github.com/mitchellh/gon) was used to perform the notarization.
the latest stable release of gon uses the altool command-line utility for notarization:
https://github.com/mitchellh/gon/blob/v0.2.5/notarize/upload.go#L41

Using altool for notarization is now deprecated by Apple and support for notarization via this tool is scheduled to be disabled 2023-11-01:
https://developer.apple.com/news/?id=y5mjxqmn

Furthermore, gon was archived

* **What is the new behavior?**
<!-- if this is a feature change -->
I switched to https://github.com/Bearer/gon that has included https://github.com/mitchellh/gon/pull/72, hoping the maintainers will take the responsibility of maintaining the project.
I added also AC_PROVIDER env var which is mandatory with the new notarytool.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
I split the signing/notarization of the bundle, because the Bearer fork does not include support for `--deep` signing.

Test release here:  
[Uploading ArduinoCreateAgent-1.3.4-rc2-osx-amd64-installer.zip…]()
