### PR TITLE
Fix installbuilder not able to produce complete artifacts for linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,14 +370,17 @@ jobs:
         include:
           - os: ubuntu-20.04
             platform-name: linux
+            installbuilder-name: linux-x64
             installer-extension: .run
           - os: windows-2019
             arch: 386
             platform-name: windows
+            installbuilder-name: windows
             extension: .exe
             installer-extension: .exe
           - os: windows-2019
             platform-name: windows
+            installbuilder-name: windows
             extension: .exe
             installer-extension: .exe
 
@@ -418,12 +421,7 @@ jobs:
 
         # installbuilder reads the env vars with certs paths and use it to sign the installer.
       - name: Launch Bitrock installbuilder
-        run: |
-          if [[ ${{matrix.platform-name}} == "linux" ]]; then
-            ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.platform-name }}-x64 --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} architecture=${{ matrix.arch }}
-          else
-            ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.platform-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} architecture=${{ matrix.arch }}
-          fi
+        run: ${{ env.INSTALLBUILDER_PATH }} build installer.xml ${{ matrix.installbuilder-name }} --verbose --license /tmp/license.xml  --setvars ${{ env.INSTALLER_VARS }} architecture=${{ matrix.arch }}
 
       - name: Generate archive
         run: tar -czvf ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.platform-name }}-${{ matrix.arch }}-installer.tar.gz ArduinoCreateAgent-${GITHUB_REF##*/}-${{ matrix.platform-name }}-${{ matrix.arch }}-installer${{matrix.installer-extension}}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Installer Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Fix #854 

The condition was wrong: we were only using the else branch. This was causing the linux installers to not contain the actual binary. We do not support running installbuilder with `linux` as a target, we support `linux-x64`

* **What is the new behavior?**
<!-- if this is a feature change -->
The installbuider linux installers are generated the right way.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
