### PR TITLE
Correct message re: enabling logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func loop() {
 	}
 
 	if !*verbose {
-		log.Println("You can enter verbose mode to see all logging by starting with the -v command line switch.")
+		log.Println("You can enter verbose mode to see all logging by setting the v key in the configuration file to true.")
 		log.SetOutput(io.Discard)
 	}
 


### PR DESCRIPTION
## Please check if the PR fulfills these requirements

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [N/A] Tests for the changes have been added (for bug fixes / features)

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If the `v` key is not set to `true` in the configuration file, Arduino Create Agent prints a seemingly helpful message to the terminal:

```text
You can enter verbose mode to see all logging by starting with the -v command line switch.
```

However, it is not helpful after all because there is no `-v` command line flag. The sole mechanism for controlling logging is the `v` key of [the configuration file](https://github.com/arduino/arduino-create-agent/wiki/Advanced-usage#the-configuration-file-location). If the user follows the instructions they will get an error:

```text
$ Arduino_Create_Agent -v
flag provided but not defined: -v
Usage of C:\Users\per\AppData\Roaming\ArduinoCreateAgent\Arduino_Create_Agent.exe:
  -additional-config string
       	config file path (default "config.ini")
  -gc string
       	Deprecated. Use the config.ini file (default "std")
  -generateCert
    
  -hibernate
       	start hibernated
  -ls
       	launch self 5 seconds later
  -regex string
       	Deprecated. Use the config.ini file (default "usb|acm|com")
```


Previously this message instructed the user to enable logging via a `-v` command line flag. However, Arduino Create Agent doesn't have a `-v` flag. The sole mechanism for controlling logging is the `v` key of the configuration file.


## What is the new behavior?

Change the message to specify the use of the configuration file instead of a non-existent flag.

## Does this PR introduce a breaking change?

No

## Other information

An alternative solution would be to implement the mythical `-v` flag. However, I don't think there is a need for such a flag.

The end users don't have any need to run Arduino Create Agent from the command line under normal usage, and when they are running it from the command line it is likely to be during troubleshooting, when logging will be useful. Since [logging is enabled by default](https://github.com/arduino/arduino-create-agent/blob/e5653008d9882312ef1936d0ddc5ce0c08c2655e/main.go#L85), it will be rare that a user would have the need to change the logging behavior.