### PR TITLE
Fix origins present in `config.ini` being ignored

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	cert "github.com/arduino/arduino-create-agent/certificates"
@@ -372,10 +373,15 @@ func loop() {
 		extraOrigins = append(extraOrigins, "https://127.0.0.1:"+port)
 	}
 
-	allowOrigings := []string{*origins}
-	allowOrigings = append(allowOrigings, extraOrigins...)
+	allowOrigins := strings.Split(*origins, ",")
+	// We need to trim possible spaces from the origins, otherwise the CORS middleware
+	// validation might not work as expected
+	for i := range allowOrigins {
+		allowOrigins[i] = strings.TrimSpace(allowOrigins[i])
+	}
+	allowOrigins = append(allowOrigins, extraOrigins...)
 	r.Use(cors.New(cors.Config{
-		AllowOrigins:        allowOrigings,
+		AllowOrigins:        allowOrigins,
 		AllowMethods:        []string{"PUT", "GET", "POST", "DELETE"},
 		AllowHeaders:        []string{"Origin", "Authorization", "Content-Type"},
 		ExposeHeaders:       []string{},

--- a/main.go
+++ b/main.go
@@ -381,6 +381,7 @@ func loop() {
 	}
 	allowOrigins = append(allowOrigins, extraOrigins...)
 	r.Use(cors.New(cors.Config{
+		AllowWildcard:       true,
 		AllowOrigins:        allowOrigins,
 		AllowMethods:        []string{"PUT", "GET", "POST", "DELETE"},
 		AllowHeaders:        []string{"Origin", "Authorization", "Content-Type"},


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Bug fix
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The agent (after #873) is no longer able to pick user defined origins in the `config.ini` file.
* **What is the new behavior?**
<!-- if this is a feature change -->
Restored behavior
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
* **Other information**:
<!-- Any additional information that could help the review process -->
