### PR TITLE
move Index init after reading the ini config

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,17 +177,11 @@ func loop() {
 		os.Exit(0)
 	}
 
-	// Instantiate Index
-	Index = index.Init(*indexURL, config.GetDataDir())
-
 	logger := func(msg string) {
 		mapD := map[string]string{"DownloadStatus": "Pending", "Msg": msg}
 		mapB, _ := json.Marshal(mapD)
 		h.broadcastSys <- mapB
 	}
-
-	// Instantiate Tools
-	Tools = *tools.New(config.GetDataDir(), Index, logger)
 
 	// Let's handle the config
 	configDir := config.GetDefaultConfigDir()
@@ -250,6 +244,10 @@ func loop() {
 			log.Infof("using additional config from %s", additionalConfigPath.String())
 		}
 	}
+
+	// Instantiate Index and Tools
+	Index = index.Init(*indexURL, config.GetDataDir())
+	Tools = *tools.New(config.GetDataDir(), Index, logger)
 
 	// see if we are supposed to wait 5 seconds
 	if *isLaunchSelf {

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ var (
 	hostname       = iniConf.String("hostname", "unknown-hostname", "Override the hostname we get from the OS")
 	httpProxy      = iniConf.String("httpProxy", "", "Proxy server for HTTP requests")
 	httpsProxy     = iniConf.String("httpsProxy", "", "Proxy server for HTTPS requests")
-	indexURL       = iniConf.String("indexURL", "https://downloads.arduino.cc/packages/package_staging_index.json", "The address from where to download the index json containing the location of upload tools")
+	indexURL       = iniConf.String("indexURL", "https://downloads.arduino.cc/packages/package_index.json", "The address from where to download the index json containing the location of upload tools")
 	iniConf        = flag.NewFlagSet("ini", flag.ContinueOnError)
 	logDump        = iniConf.String("log", "off", "off = (default)")
 	origins        = iniConf.String("origins", "", "Allowed origin list for CORS")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
Moving the initialization of the Index after reading the .ini config.

- **What is the current behavior?**
Currently changing the `indexURL` config has no effect because the assignment of that value is performed before reading the ini file.

* **What is the new behavior?**
We now read all the configs first and then assign the `indexURL` value.

- **Does this PR introduce a breaking change?**
no

* **Other information**:
Tested on linux