### PR TITLE
[skip-changelog] move tests using staging index to production one

### DIFF
--- a/index/index_test.go
+++ b/index/index_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	indexURL := "https://downloads.arduino.cc/packages/package_staging_index.json"
+	indexURL := "https://downloads.arduino.cc/packages/package_index.json"
 	// Instantiate Index
 	tempDir := paths.New(t.TempDir()).Join(".arduino-create")
 	Index := Init(indexURL, tempDir)
 	require.DirExists(t, tempDir.String())
-	fileName := "package_staging_index.json"
+	fileName := "package_index.json"
 	signatureName := fileName + ".sig"
 	parsedURL, _ := url.Parse(indexURL)
 	require.Equal(t, Index.IndexURL, *parsedURL)

--- a/main_test.go
+++ b/main_test.go
@@ -89,7 +89,7 @@ func TestUploadHandlerAgainstEvilFileNames(t *testing.T) {
 
 func TestInstallToolV2(t *testing.T) {
 
-	indexURL := "https://downloads.arduino.cc/packages/package_staging_index.json"
+	indexURL := "https://downloads.arduino.cc/packages/package_index.json"
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
@@ -170,7 +170,7 @@ func TestInstallToolV2(t *testing.T) {
 }
 
 func TestInstalledHead(t *testing.T) {
-	indexURL := "https://downloads.arduino.cc/packages/package_staging_index.json"
+	indexURL := "https://downloads.arduino.cc/packages/package_index.json"
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -37,7 +37,7 @@ import (
 // Usage:
 // You have to call the New() function passing it the required parameters:
 //
-// 	index = index.Init("https://downloads.arduino.cc/packages/package_staging_index.json", dataDir)
+// 	index = index.Init("https://downloads.arduino.cc/packages/package_index.json", dataDir)
 // 	tools := tools.New(dataDir, index, logger)
 
 // Tools will represent the installed tools

--- a/v2/pkgs/tools_test.go
+++ b/v2/pkgs/tools_test.go
@@ -41,7 +41,7 @@ func TestTools(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	indexURL := "https://downloads.arduino.cc/packages/package_staging_index.json"
+	indexURL := "https://downloads.arduino.cc/packages/package_index.json"
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
@@ -122,7 +122,7 @@ func TestEvilFilename(t *testing.T) {
 	// Initialize indexes with a temp folder
 	tmp := t.TempDir()
 
-	indexURL := "https://downloads.arduino.cc/packages/package_staging_index.json"
+	indexURL := "https://downloads.arduino.cc/packages/package_index.json"
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
@@ -191,7 +191,7 @@ func TestInstalledHead(t *testing.T) {
 	// Initialize indexes with a temp folder
 	tmp := t.TempDir()
 
-	indexURL := "https://downloads.arduino.cc/packages/package_staging_index.json"
+	indexURL := "https://downloads.arduino.cc/packages/package_index.json"
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [X] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
followup of b350f563ff253d05199dda8e07718518a6cef30d
- **What is the current behavior?**
<!-- You can also link to an open issue here -->
Tests used the `package_staging_index.json`
* **What is the new behavior?**
<!-- if this is a feature change -->
Tests are now using the `package_index.json`
- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
no
* **Other information**:
<!-- Any additional information that could help the review process -->
