### PR TITLE
Restore functionality of 'is_open' field in portlist

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -239,6 +239,7 @@ func (sp *SerialPortList) remove(removedPort *discovery.Port) {
 	})
 }
 
+// MarkPortAsOpened marks a port as opened by the user
 func (sp *SerialPortList) MarkPortAsOpened(portname string) {
 	sp.portsLock.Lock()
 	defer sp.portsLock.Unlock()
@@ -248,6 +249,7 @@ func (sp *SerialPortList) MarkPortAsOpened(portname string) {
 	}
 }
 
+// MarkPortAsClosed marks a port as no more opened by the user
 func (sp *SerialPortList) MarkPortAsClosed(portname string) {
 	sp.portsLock.Lock()
 	defer sp.portsLock.Unlock()

--- a/serial.go
+++ b/serial.go
@@ -239,6 +239,33 @@ func (sp *SerialPortList) remove(removedPort *discovery.Port) {
 	})
 }
 
+func (sp *SerialPortList) MarkPortAsOpened(portname string) {
+	sp.portsLock.Lock()
+	defer sp.portsLock.Unlock()
+	port := sp.getPortByName(portname)
+	if port != nil {
+		port.IsOpen = true
+	}
+}
+
+func (sp *SerialPortList) MarkPortAsClosed(portname string) {
+	sp.portsLock.Lock()
+	defer sp.portsLock.Unlock()
+	port := sp.getPortByName(portname)
+	if port != nil {
+		port.IsOpen = false
+	}
+}
+
+func (sp *SerialPortList) getPortByName(portname string) *SpPortItem {
+	for _, port := range sp.Ports {
+		if port.Name == portname {
+			return port
+		}
+	}
+	return nil
+}
+
 func spErr(err string) {
 	//log.Println("Sending err back: ", err)
 	//h.broadcastSys <- []byte(err)

--- a/serialport.go
+++ b/serialport.go
@@ -39,6 +39,7 @@ type serport struct {
 	// The serial port connection.
 	portConf *SerialConfig
 	portIo   io.ReadWriteCloser
+	portName string
 
 	// Keep track of whether we're being actively closed
 	// just so we don't show scary error messages
@@ -305,6 +306,7 @@ func spHandlerOpen(portname string, baud int, buftype string) {
 		sendRaw:      make(chan string),
 		portConf:     conf,
 		portIo:       sp,
+		portName:     portname,
 		BufferType:   buftype}
 
 	var bw Bufferflow
@@ -326,6 +328,7 @@ func spHandlerOpen(portname string, baud int, buftype string) {
 	sh.Register(p)
 	defer sh.Unregister(p)
 
+	serialPorts.MarkPortAsOpened(portname)
 	serialPorts.List()
 
 	// this is internally buffered thread to not send to serial port if blocked
@@ -349,5 +352,6 @@ func spHandlerClose(p *serport) {
 func spCloseReal(p *serport) {
 	p.bufferwatcher.Close()
 	p.portIo.Close()
+	serialPorts.MarkPortAsClosed(p.portName)
 	serialPorts.List()
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
Restore functionality of 'is_open' field in portlist

- **What is the current behavior?**
is_open is always false

* **What is the new behavior?**
is_open is true while the port is open for monitoring

- **Does this PR introduce a breaking change?**
No

* **Other information**:
