### PR TITLE
Manage the HTTPS certificate from the menu and ask Safari users to install it at startup

### DIFF
--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -287,7 +287,7 @@ func PromptInstallCertsSafari() bool {
 	}
 	oscmd := exec.Command("osascript", "-e", "display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nIf you use Safari, you need to install it.\" buttons {\"Do not install\", \"Install the certificate for Safari\"} default button 2 with title \"Arduino Agent: Install Certificates\"")
 	pressed, _ := oscmd.Output()
-	return string(pressed) == "button returned:Install the certificate for Safari"
+	return strings.Contains(string(pressed), "button returned:Install the certificate for Safari")
 }
 
 // PromptExpiredCerts prompts the user to update the HTTPS certificates if they are using Safari
@@ -296,7 +296,7 @@ func PromptExpiredCerts(certDir *paths.Path) {
 		log.Errorf("cannot check if certificates are expired something went wrong: %s", err)
 	} else if expired {
 		oscmd := exec.Command("osascript", "-e", "display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nYour certificate is expired or close to expiration. Do you want to update it?\" buttons {\"Do not update\", \"Update the certificate for Safari\"} default button 2 with title \"Arduino Agent: Update Certificates\"")
-		if pressed, _ := oscmd.Output(); string(pressed) == "button returned:Update the certificate for Safari" {
+		if pressed, _ := oscmd.Output(); strings.Contains(string(pressed), "button returned:Update the certificate for Safari") {
 			err := UninstallCertificates()
 			if err != nil {
 				log.Errorf("cannot uninstall certificates something went wrong: %s", err)

--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -283,7 +283,7 @@ func isExpired() (bool, error) {
 
 // PromptInstallCertsSafari prompts the user to install the HTTPS certificates if they are using Safari
 func PromptInstallCertsSafari() bool {
-	buttonPressed := utilities.UserPrompt("display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nIf you use Safari, you need to install it.\" buttons {\"Do not install\", \"Install the certificate for Safari\"} default button 2 with title \"Arduino Agent: Install Certificates\"")
+	buttonPressed := utilities.UserPrompt("display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nIf you use Safari, you need to install it.\" buttons {\"Do not install\", \"Install the certificate for Safari\"} default button 2 with title \"Arduino Agent: Install certificate\"")
 	return strings.Contains(string(buttonPressed), "button returned:Install the certificate for Safari")
 }
 
@@ -292,7 +292,7 @@ func PromptExpiredCerts(certDir *paths.Path) {
 	if expired, err := isExpired(); err != nil {
 		log.Errorf("cannot check if certificates are expired something went wrong: %s", err)
 	} else if expired {
-		buttonPressed := utilities.UserPrompt("display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nYour certificate is expired or close to expiration. Do you want to update it?\" buttons {\"Do not update\", \"Update the certificate for Safari\"} default button 2 with title \"Arduino Agent: Update Certificates\"")
+		buttonPressed := utilities.UserPrompt("display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nYour certificate is expired or close to expiration. Do you want to update it?\" buttons {\"Do not update\", \"Update the certificate for Safari\"} default button 2 with title \"Arduino Agent: Update certificate\"")
 		if strings.Contains(string(buttonPressed), "button returned:Update the certificate for Safari") {
 			err := UninstallCertificates()
 			if err != nil {

--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -267,3 +267,12 @@ func DeleteCertificates(certDir *paths.Path) {
 	certDir.Join("cert.pem").Remove()
 	certDir.Join("cert.cer").Remove()
 }
+
+// isExpired checks if a certificate is expired or about to expire (less than 1 month)
+func isExpired() bool {
+	bound := time.Now().AddDate(0, 1, 0)
+	// TODO: manage errors
+	dateS, _ := GetExpirationDate()
+	date, _ := time.Parse(time.DateTime, dateS)
+	return date.Before(bound)
+}

--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -283,9 +283,6 @@ func isExpired() (bool, error) {
 
 // PromptInstallCertsSafari prompts the user to install the HTTPS certificates if they are using Safari
 func PromptInstallCertsSafari() bool {
-	if GetDefaultBrowserName() != "Safari" {
-		return false
-	}
 	buttonPressed := utilities.UserPrompt("display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nIf you use Safari, you need to install it.\" buttons {\"Do not install\", \"Install the certificate for Safari\"} default button 2 with title \"Arduino Agent: Install Certificates\"")
 	return strings.Contains(string(buttonPressed), "button returned:Install the certificate for Safari")
 }

--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -269,10 +269,12 @@ func DeleteCertificates(certDir *paths.Path) {
 }
 
 // isExpired checks if a certificate is expired or about to expire (less than 1 month)
-func isExpired() bool {
+func isExpired() (bool, error) {
 	bound := time.Now().AddDate(0, 1, 0)
-	// TODO: manage errors
-	dateS, _ := GetExpirationDate()
+	dateS, err := GetExpirationDate()
+	if err != nil {
+		return false, err
+	}
 	date, _ := time.Parse(time.DateTime, dateS)
-	return date.Before(bound)
+	return date.Before(bound), nil
 }

--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -285,7 +285,7 @@ func PromptInstallCertsSafari() bool {
 	if GetDefaultBrowserName() != "Safari" {
 		return false
 	}
-	oscmd := exec.Command("osascript", "-e", "display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nIf you use Safari, you need to install it.\" buttons {\"Do not install\", \"Install the certificate for Safari\"} default button 2 with title \"Install Certificates\"")
+	oscmd := exec.Command("osascript", "-e", "display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nIf you use Safari, you need to install it.\" buttons {\"Do not install\", \"Install the certificate for Safari\"} default button 2 with title \"Arduino Agent: Install Certificates\"")
 	pressed, _ := oscmd.Output()
 	return string(pressed) == "button returned:Install the certificate for Safari"
 }
@@ -295,7 +295,7 @@ func PromptExpiredCerts(certDir *paths.Path) {
 	if expired, err := isExpired(); err != nil {
 		log.Errorf("cannot check if certificates are expired something went wrong: %s", err)
 	} else if expired {
-		oscmd := exec.Command("osascript", "-e", "display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nYour certificate is expired or close to expiration. Do you want to update it?\" buttons {\"Do not update\", \"Update the certificate for Safari\"} default button 2 with title \"Update Certificates\"")
+		oscmd := exec.Command("osascript", "-e", "display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nYour certificate is expired or close to expiration. Do you want to update it?\" buttons {\"Do not update\", \"Update the certificate for Safari\"} default button 2 with title \"Arduino Agent: Update Certificates\"")
 		if pressed, _ := oscmd.Output(); string(pressed) == "button returned:Update the certificate for Safari" {
 			err := UninstallCertificates()
 			if err != nil {

--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -30,9 +30,10 @@ import (
 	"math/big"
 	"net"
 	"os"
-	"os/exec"
+	"strings"
 	"time"
 
+	"github.com/arduino/arduino-create-agent/utilities"
 	"github.com/arduino/go-paths-helper"
 	log "github.com/sirupsen/logrus"
 )
@@ -285,9 +286,8 @@ func PromptInstallCertsSafari() bool {
 	if GetDefaultBrowserName() != "Safari" {
 		return false
 	}
-	oscmd := exec.Command("osascript", "-e", "display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nIf you use Safari, you need to install it.\" buttons {\"Do not install\", \"Install the certificate for Safari\"} default button 2 with title \"Arduino Agent: Install Certificates\"")
-	pressed, _ := oscmd.Output()
-	return strings.Contains(string(pressed), "button returned:Install the certificate for Safari")
+	buttonPressed := utilities.UserPrompt("display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nIf you use Safari, you need to install it.\" buttons {\"Do not install\", \"Install the certificate for Safari\"} default button 2 with title \"Arduino Agent: Install Certificates\"")
+	return strings.Contains(string(buttonPressed), "button returned:Install the certificate for Safari")
 }
 
 // PromptExpiredCerts prompts the user to update the HTTPS certificates if they are using Safari
@@ -295,8 +295,8 @@ func PromptExpiredCerts(certDir *paths.Path) {
 	if expired, err := isExpired(); err != nil {
 		log.Errorf("cannot check if certificates are expired something went wrong: %s", err)
 	} else if expired {
-		oscmd := exec.Command("osascript", "-e", "display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nYour certificate is expired or close to expiration. Do you want to update it?\" buttons {\"Do not update\", \"Update the certificate for Safari\"} default button 2 with title \"Arduino Agent: Update Certificates\"")
-		if pressed, _ := oscmd.Output(); strings.Contains(string(pressed), "button returned:Update the certificate for Safari") {
+		buttonPressed := utilities.UserPrompt("display dialog \"The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\nYour certificate is expired or close to expiration. Do you want to update it?\" buttons {\"Do not update\", \"Update the certificate for Safari\"} default button 2 with title \"Arduino Agent: Update Certificates\"")
+		if strings.Contains(string(buttonPressed), "button returned:Update the certificate for Safari") {
 			err := UninstallCertificates()
 			if err != nil {
 				log.Errorf("cannot uninstall certificates something went wrong: %s", err)

--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -302,14 +302,19 @@ func PromptExpiredCerts(certDir *paths.Path) {
 				log.Errorf("cannot uninstall certificates something went wrong: %s", err)
 			} else {
 				DeleteCertificates(certDir)
-				GenerateCertificates(certDir)
-				err := InstallCertificate(certDir.Join("ca.cert.cer"))
-				// if something goes wrong during the cert install we remove them, so the user is able to retry
-				if err != nil {
-					log.Errorf("cannot install certificates something went wrong: %s", err)
-					DeleteCertificates(certDir)
-				}
+				GenerateAndInstallCertificates(certDir)
 			}
 		}
+	}
+}
+
+// GenerateAndInstallCertificates generates and installs the certificates
+func GenerateAndInstallCertificates(certDir *paths.Path) {
+	GenerateCertificates(certDir)
+	err := InstallCertificate(certDir.Join("ca.cert.cer"))
+	// if something goes wrong during the cert install we remove them, so the user is able to retry
+	if err != nil {
+		log.Errorf("cannot install certificates something went wrong: %s", err)
+		DeleteCertificates(certDir)
 	}
 }

--- a/certificates/install_darwin.go
+++ b/certificates/install_darwin.go
@@ -138,6 +138,18 @@ const char *getExpirationDate(char *expirationDate){
 
     return "";
 }
+
+const char *getDefaultBrowserName() {
+    NSURL *defaultBrowserURL = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL:[NSURL URLWithString:@"http://"]];
+    if (defaultBrowserURL) {
+        NSBundle *defaultBrowserBundle = [NSBundle bundleWithURL:defaultBrowserURL];
+        NSString *defaultBrowser = [defaultBrowserBundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+
+        return [defaultBrowser cStringUsingEncoding:[NSString defaultCStringEncoding]];
+    }
+
+    return "";
+}
 */
 import "C"
 import (
@@ -196,4 +208,11 @@ func GetExpirationDate() (string, error) {
 	}
 	date := C.GoString(dateString)
 	return strings.ReplaceAll(date, " +0000", ""), nil
+}
+
+// GetDefaultBrowserName returns the name of the default browser
+func GetDefaultBrowserName() string {
+	log.Infof("Retrieving default browser name")
+	p := C.getDefaultBrowserName()
+	return C.GoString(p)
 }

--- a/certificates/install_darwin.go
+++ b/certificates/install_darwin.go
@@ -154,12 +154,12 @@ const char *getDefaultBrowserName() {
 import "C"
 import (
 	"errors"
-	"os/exec"
 	"strings"
 	"unsafe"
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/arduino/arduino-create-agent/utilities"
 	"github.com/arduino/go-paths-helper"
 )
 
@@ -172,9 +172,8 @@ func InstallCertificate(cert *paths.Path) error {
 	p := C.installCert(ccert)
 	s := C.GoString(p)
 	if len(s) != 0 {
-		oscmd := exec.Command("osascript", "-e", "display dialog \""+s+"\" buttons \"OK\" with title \"Arduino Agent: Error installing certificates\"")
-		_ = oscmd.Run()
-		_ = UninstallCertificates()
+		utilities.UserPrompt("display dialog \"" + s + "\" buttons \"OK\" with title \"Arduino Agent: Error installing certificates\"")
+		UninstallCertificates()
 		return errors.New(s)
 	}
 	return nil
@@ -187,8 +186,7 @@ func UninstallCertificates() error {
 	p := C.uninstallCert()
 	s := C.GoString(p)
 	if len(s) != 0 {
-		oscmd := exec.Command("osascript", "-e", "display dialog \""+s+"\" buttons \"OK\" with title \"Arduino Agent: Error uninstalling certificates\"")
-		_ = oscmd.Run()
+		utilities.UserPrompt("display dialog \"" + s + "\" buttons \"OK\" with title \"Arduino Agent: Error uninstalling certificates\"")
 		return errors.New(s)
 	}
 	return nil
@@ -202,8 +200,7 @@ func GetExpirationDate() (string, error) {
 	p := C.getExpirationDate(dateString)
 	s := C.GoString(p)
 	if len(s) != 0 {
-		oscmd := exec.Command("osascript", "-e", "display dialog \""+s+"\" buttons \"OK\" with title \"Arduino Agent: Error retrieving expiration date\"")
-		_ = oscmd.Run()
+		utilities.UserPrompt("display dialog \"" + s + "\" buttons \"OK\" with title \"Arduino Agent: Error retrieving expiration date\"")
 		return "", errors.New(s)
 	}
 	date := C.GoString(dateString)

--- a/certificates/install_default.go
+++ b/certificates/install_default.go
@@ -36,3 +36,9 @@ func UninstallCertificates() error {
 	log.Warn("platform not supported for the certificates uninstall")
 	return errors.New("platform not supported for the certificates uninstall")
 }
+
+// GetExpirationDate won't do anything on unsupported Operative Systems
+func GetExpirationDate() (string, error) {
+	log.Warn("platform not supported for retrieving certificates expiration date")
+	return "", errors.New("platform not supported for retrieving certificates expiration date")
+}

--- a/certificates/install_default.go
+++ b/certificates/install_default.go
@@ -42,3 +42,9 @@ func GetExpirationDate() (string, error) {
 	log.Warn("platform not supported for retrieving certificates expiration date")
 	return "", errors.New("platform not supported for retrieving certificates expiration date")
 }
+
+// GetDefaultBrowserName won't do anything on unsupported Operative Systems
+func GetDefaultBrowserName() string {
+	log.Warn("platform not supported for retrieving default browser name")
+	return ""
+}

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/arduino/go-paths-helper"
+	"github.com/go-ini/ini"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -123,4 +124,21 @@ func GenerateConfig(destDir *paths.Path) *paths.Path {
 	}
 	log.Infof("generated config in %s", configPath)
 	return configPath
+}
+
+// SetInstallCertsIni sets installCerts value to true in the config
+func SetInstallCertsIni(filename string, value string) error {
+	cfg, err := ini.LoadSources(ini.LoadOptions{IgnoreInlineComment: false, AllowPythonMultilineValues: true}, filename)
+	if err != nil {
+		return err
+	}
+	_, err = cfg.Section("").NewKey("installCerts", value)
+	if err != nil {
+		return err
+	}
+	err = cfg.SaveTo(filename)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -227,7 +227,12 @@ func loop() {
 		if exist, err := installCertsKeyExists(configPath.String()); err != nil {
 			log.Panicf("config.ini cannot be parsed: %s", err)
 		} else if !exist {
-			if cert.PromptInstallCertsSafari() {
+			if config.CertsExist() {
+				err = config.SetInstallCertsIni(configPath.String(), "true")
+				if err != nil {
+					log.Panicf("config.ini cannot be parsed: %s", err)
+				}
+			} else if cert.PromptInstallCertsSafari() {
 				err = config.SetInstallCertsIni(configPath.String(), "true")
 				if err != nil {
 					log.Panicf("config.ini cannot be parsed: %s", err)

--- a/main.go
+++ b/main.go
@@ -237,14 +237,7 @@ func loop() {
 				if err != nil {
 					log.Panicf("config.ini cannot be parsed: %s", err)
 				}
-				certDir := config.GetCertificatesDir()
-				cert.GenerateCertificates(certDir)
-				err := cert.InstallCertificate(certDir.Join("ca.cert.cer"))
-				// if something goes wrong during the cert install we remove them, so the user is able to retry
-				if err != nil {
-					log.Errorf("cannot install certificates something went wrong: %s", err)
-					cert.DeleteCertificates(certDir)
-				}
+				cert.GenerateAndInstallCertificates(config.GetCertificatesDir())
 			} else {
 				err = config.SetInstallCertsIni(configPath.String(), "false")
 				if err != nil {
@@ -384,14 +377,7 @@ func loop() {
 			} else if cert.PromptInstallCertsSafari() {
 				// installing the certificates from scratch at this point should only happen if
 				// something went wrong during previous installation attempts
-				certDir := config.GetCertificatesDir()
-				cert.GenerateCertificates(certDir)
-				err := cert.InstallCertificate(certDir.Join("ca.cert.cer"))
-				// if something goes wrong during the cert install we remove them, so the user is able to retry
-				if err != nil {
-					log.Errorf("cannot install certificates something went wrong: %s", err)
-					cert.DeleteCertificates(certDir)
-				}
+				cert.GenerateAndInstallCertificates(config.GetCertificatesDir())
 			} else {
 				err = config.SetInstallCertsIni(configPath.String(), "false")
 				if err != nil {

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func loop() {
 
 	// if the default browser is Safari, prompt the user to install HTTPS certificates
 	// and eventually install them
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" && cert.GetDefaultBrowserName() == "Safari" {
 		if exist, err := installCertsKeyExists(configPath.String()); err != nil {
 			log.Panicf("config.ini cannot be parsed: %s", err)
 		} else if !exist {
@@ -370,7 +370,7 @@ func loop() {
 	}
 
 	// check if the HTTPS certificates are expired and prompt the user to update them on macOS
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" && cert.GetDefaultBrowserName() == "Safari" {
 		if *installCerts {
 			if config.CertsExist() {
 				cert.PromptExpiredCerts(config.GetCertificatesDir())

--- a/main.go
+++ b/main.go
@@ -228,7 +228,7 @@ func loop() {
 			log.Panicf("config.ini cannot be parsed: %s", err)
 		} else if !exist {
 			if cert.PromptInstallCertsSafari() {
-				err = modifyIni(configPath.String(), "true")
+				err = config.SetInstallCertsIni(configPath.String(), "true")
 				if err != nil {
 					log.Panicf("config.ini cannot be parsed: %s", err)
 				}
@@ -241,7 +241,7 @@ func loop() {
 					cert.DeleteCertificates(certDir)
 				}
 			} else {
-				err = modifyIni(configPath.String(), "false")
+				err = config.SetInstallCertsIni(configPath.String(), "false")
 				if err != nil {
 					log.Panicf("config.ini cannot be parsed: %s", err)
 				}
@@ -522,22 +522,6 @@ func parseIni(filename string) (args []string, err error) {
 	}
 
 	return args, nil
-}
-
-func modifyIni(filename string, value string) error {
-	cfg, err := ini.LoadSources(ini.LoadOptions{IgnoreInlineComment: false, AllowPythonMultilineValues: true}, filename)
-	if err != nil {
-		return err
-	}
-	_, err = cfg.Section("").NewKey("installCerts", value)
-	if err != nil {
-		return err
-	}
-	err = cfg.SaveTo(filename)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func installCertsKeyExists(filename string) (bool, error) {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ import (
 	"html/template"
 	"io"
 	"os"
-	"os/exec"
 	"regexp"
 	"runtime"
 	"runtime/debug"
@@ -40,6 +39,7 @@ import (
 	"github.com/arduino/arduino-create-agent/systray"
 	"github.com/arduino/arduino-create-agent/tools"
 	"github.com/arduino/arduino-create-agent/updater"
+	"github.com/arduino/arduino-create-agent/utilities"
 	v2 "github.com/arduino/arduino-create-agent/v2"
 	paths "github.com/arduino/go-paths-helper"
 	cors "github.com/gin-contrib/cors"
@@ -178,7 +178,7 @@ func loop() {
 	// If we are updating manually from 1.2.7 to 1.3.0 we have to uninstall the old agent manually first.
 	// This check will inform the user if he needs to run the uninstall first
 	if runtime.GOOS == "darwin" && oldInstallExists() {
-		printDialog("Old agent installation of the Arduino Create Agent found, please uninstall it before launching the new one")
+		utilities.UserPrompt("display dialog \"Old agent installation of the Arduino Create Agent found, please uninstall it before launching the new one\" buttons \"OK\" with title \"Error\"")
 		os.Exit(0)
 	}
 
@@ -496,12 +496,6 @@ func oldInstallExists() bool {
 		return false
 	}
 	return oldAgentPath.Join("ArduinoCreateAgent.app").Exist()
-}
-
-// printDialog will print a GUI error dialog on macos
-func printDialog(dialogText string) {
-	oscmd := exec.Command("osascript", "-e", "display dialog \""+dialogText+"\" buttons \"OK\" with title \"Error\"")
-	_ = oscmd.Run()
 }
 
 func parseIni(filename string) (args []string, err error) {

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -21,13 +21,13 @@ package systray
 
 import (
 	"os"
-	"os/exec"
 	"runtime"
 
 	"fyne.io/systray"
 	cert "github.com/arduino/arduino-create-agent/certificates"
 	"github.com/arduino/arduino-create-agent/config"
 	"github.com/arduino/arduino-create-agent/icon"
+	"github.com/arduino/arduino-create-agent/utilities"
 	"github.com/go-ini/ini"
 	log "github.com/sirupsen/logrus"
 	"github.com/skratchdot/open-golang/open"
@@ -133,8 +133,7 @@ func (s *Systray) start() {
 				} else {
 					infoMsg = infoMsg + "- Certificate installed: No\n- Certificate trusted: N/A\n- Certificate expiration date: N/A"
 				}
-				oscmd := exec.Command("osascript", "-e", "display dialog \""+infoMsg+"\" buttons \"OK\" with title \"Arduino Agent: certificates info\"")
-				_ = oscmd.Run()
+				utilities.UserPrompt("display dialog \"" + infoMsg + "\" buttons \"OK\" with title \"Arduino Agent: certificates info\"")
 			case <-mPause.ClickedCh:
 				s.Pause()
 			case <-mQuit.ClickedCh:

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -114,6 +114,7 @@ func (s *Systray) start() {
 					if err != nil {
 						log.Errorf("cannot set installCerts value in config.ini: %s", err)
 					}
+					s.Restart()
 				} else if strings.Contains(pressedButton, "Uninstall certificate for Safari") {
 					err := cert.UninstallCertificates()
 					if err != nil {
@@ -125,8 +126,8 @@ func (s *Systray) start() {
 							log.Errorf("cannot set installCerts value in config.ini: %s", err)
 						}
 					}
+					s.Restart()
 				}
-				s.Restart()
 			case <-mPause.ClickedCh:
 				s.Pause()
 			case <-mQuit.ClickedCh:

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -109,14 +109,8 @@ func (s *Systray) start() {
 				}
 				pressedButton := utilities.UserPrompt("display dialog \"" + infoMsg + "\" buttons " + buttons + " with title \"Arduino Agent: manage HTTPS certificates\"")
 				if strings.Contains(pressedButton, "Install certificate for Safari") {
-					cert.GenerateCertificates(certDir)
-					err := cert.InstallCertificate(certDir.Join("ca.cert.cer"))
-					// if something goes wrong during the cert install we remove them, so the user is able to retry
-					if err != nil {
-						log.Errorf("cannot install certificates something went wrong: %s", err)
-						cert.DeleteCertificates(certDir)
-					}
-					err = config.SetInstallCertsIni(s.currentConfigFilePath.String(), "true")
+					cert.GenerateAndInstallCertificates(certDir)
+					err := config.SetInstallCertsIni(s.currentConfigFilePath.String(), "true")
 					if err != nil {
 						log.Errorf("cannot set installCerts value in config.ini: %s", err)
 					}

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -108,6 +108,10 @@ func (s *Systray) start() {
 					log.Errorf("cannot install certificates something went wrong: %s", err)
 					cert.DeleteCertificates(certDir)
 				}
+				err = config.SetInstallCertsIni(s.currentConfigFilePath.String(), "true")
+				if err != nil {
+					log.Errorf("cannot set installCerts value in config.ini: %s", err)
+				}
 				s.Restart()
 			case <-mRemoveCerts.ClickedCh:
 				err := cert.UninstallCertificates()

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -65,7 +65,7 @@ func (s *Systray) start() {
 	mRmCrashes := systray.AddMenuItem("Remove crash reports", "")
 	s.updateMenuItem(mRmCrashes, config.LogsIsEmpty())
 
-	mManageCerts := systray.AddMenuItem("Manage HTTPS certificates", "HTTPS Certs")
+	mManageCerts := systray.AddMenuItem("Manage HTTPS certificate", "HTTPS Certs")
 	// On linux/windows chrome/firefox/edge(chromium) the agent works without problems on plain HTTP,
 	// so we disable the menuItem to generate/install the certificates
 	if runtime.GOOS != "darwin" {
@@ -95,7 +95,7 @@ func (s *Systray) start() {
 				s.updateMenuItem(mRmCrashes, config.LogsIsEmpty())
 			case <-mManageCerts.ClickedCh:
 				infoMsg := "The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\n\nYour HTTPS certificate status:\n"
-				buttons := "{\"OK\", \"Install certificate for Safari\"}"
+				buttons := "{\"Install certificate for Safari\", \"OK\"} default button \"OK\""
 				certDir := config.GetCertificatesDir()
 				if config.CertsExist() {
 					expDate, err := cert.GetExpirationDate()
@@ -103,11 +103,11 @@ func (s *Systray) start() {
 						log.Errorf("cannot get certificates expiration date, something went wrong: %s", err)
 					}
 					infoMsg = infoMsg + "- Certificate installed: Yes\n- Certificate trusted: Yes\n- Certificate expiration date: " + expDate
-					buttons = "{\"OK\", \"Uninstall certificate for Safari\"}"
+					buttons = "{\"Uninstall certificate for Safari\", \"OK\"} default button \"OK\""
 				} else {
 					infoMsg = infoMsg + "- Certificate installed: No\n- Certificate trusted: N/A\n- Certificate expiration date: N/A"
 				}
-				pressedButton := utilities.UserPrompt("display dialog \"" + infoMsg + "\" buttons " + buttons + " with title \"Arduino Agent: manage HTTPS certificates\"")
+				pressedButton := utilities.UserPrompt("display dialog \"" + infoMsg + "\" buttons " + buttons + " with title \"Arduino Agent: Manage HTTPS certificate\"")
 				if strings.Contains(pressedButton, "Install certificate for Safari") {
 					cert.GenerateAndInstallCertificates(certDir)
 					err := config.SetInstallCertsIni(s.currentConfigFilePath.String(), "true")

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -95,7 +95,7 @@ func (s *Systray) start() {
 				s.updateMenuItem(mRmCrashes, config.LogsIsEmpty())
 			case <-mManageCerts.ClickedCh:
 				infoMsg := "The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\n\nYour HTTPS certificate status:\n"
-				buttons := "{\"Install certificate for Safari\", \"OK\"} default button \"OK\""
+				buttons := "{\"Install the certificate for Safari\", \"OK\"} default button \"OK\""
 				certDir := config.GetCertificatesDir()
 				if config.CertsExist() {
 					expDate, err := cert.GetExpirationDate()
@@ -103,7 +103,7 @@ func (s *Systray) start() {
 						log.Errorf("cannot get certificates expiration date, something went wrong: %s", err)
 					}
 					infoMsg = infoMsg + "- Certificate installed: Yes\n- Certificate trusted: Yes\n- Certificate expiration date: " + expDate
-					buttons = "{\"Uninstall certificate for Safari\", \"OK\"} default button \"OK\""
+					buttons = "{\"Uninstall the certificate for Safari\", \"OK\"} default button \"OK\""
 				} else {
 					infoMsg = infoMsg + "- Certificate installed: No\n- Certificate trusted: N/A\n- Certificate expiration date: N/A"
 				}

--- a/systray/systray_real.go
+++ b/systray/systray_real.go
@@ -22,6 +22,7 @@ package systray
 import (
 	"os"
 	"runtime"
+	"strings"
 
 	"fyne.io/systray"
 	cert "github.com/arduino/arduino-create-agent/certificates"
@@ -64,18 +65,11 @@ func (s *Systray) start() {
 	mRmCrashes := systray.AddMenuItem("Remove crash reports", "")
 	s.updateMenuItem(mRmCrashes, config.LogsIsEmpty())
 
-	mGenCerts := systray.AddMenuItem("Generate and Install HTTPS certificates", "HTTPS Certs")
-	mRemoveCerts := systray.AddMenuItem("Remove HTTPS certificates", "")
-	mCertsInfo := systray.AddMenuItem("Show HTTPS certificates info", "")
+	mManageCerts := systray.AddMenuItem("Manage HTTPS certificates", "HTTPS Certs")
 	// On linux/windows chrome/firefox/edge(chromium) the agent works without problems on plain HTTP,
 	// so we disable the menuItem to generate/install the certificates
 	if runtime.GOOS != "darwin" {
-		s.updateMenuItem(mGenCerts, true)
-		s.updateMenuItem(mRemoveCerts, true)
-		s.updateMenuItem(mCertsInfo, true)
-	} else {
-		s.updateMenuItem(mGenCerts, config.CertsExist())
-		s.updateMenuItem(mRemoveCerts, !config.CertsExist())
+		s.updateMenuItem(mManageCerts, true)
 	}
 
 	// Add pause/quit
@@ -99,41 +93,46 @@ func (s *Systray) start() {
 			case <-mRmCrashes.ClickedCh:
 				RemoveCrashes()
 				s.updateMenuItem(mRmCrashes, config.LogsIsEmpty())
-			case <-mGenCerts.ClickedCh:
-				certDir := config.GetCertificatesDir()
-				cert.GenerateCertificates(certDir)
-				err := cert.InstallCertificate(certDir.Join("ca.cert.cer"))
-				// if something goes wrong during the cert install we remove them, so the user is able to retry
-				if err != nil {
-					log.Errorf("cannot install certificates something went wrong: %s", err)
-					cert.DeleteCertificates(certDir)
-				}
-				err = config.SetInstallCertsIni(s.currentConfigFilePath.String(), "true")
-				if err != nil {
-					log.Errorf("cannot set installCerts value in config.ini: %s", err)
-				}
-				s.Restart()
-			case <-mRemoveCerts.ClickedCh:
-				err := cert.UninstallCertificates()
-				if err != nil {
-					log.Errorf("cannot uninstall certificates something went wrong: %s", err)
-				} else {
-					certDir := config.GetCertificatesDir()
-					cert.DeleteCertificates(certDir)
-				}
-				s.Restart()
-			case <-mCertsInfo.ClickedCh:
+			case <-mManageCerts.ClickedCh:
 				infoMsg := "The Arduino Agent needs a local HTTPS certificate to work correctly with Safari.\n\nYour HTTPS certificate status:\n"
+				buttons := "{\"OK\", \"Install certificate for Safari\"}"
+				certDir := config.GetCertificatesDir()
 				if config.CertsExist() {
 					expDate, err := cert.GetExpirationDate()
 					if err != nil {
 						log.Errorf("cannot get certificates expiration date, something went wrong: %s", err)
 					}
 					infoMsg = infoMsg + "- Certificate installed: Yes\n- Certificate trusted: Yes\n- Certificate expiration date: " + expDate
+					buttons = "{\"OK\", \"Uninstall certificate for Safari\"}"
 				} else {
 					infoMsg = infoMsg + "- Certificate installed: No\n- Certificate trusted: N/A\n- Certificate expiration date: N/A"
 				}
-				utilities.UserPrompt("display dialog \"" + infoMsg + "\" buttons \"OK\" with title \"Arduino Agent: certificates info\"")
+				pressedButton := utilities.UserPrompt("display dialog \"" + infoMsg + "\" buttons " + buttons + " with title \"Arduino Agent: manage HTTPS certificates\"")
+				if strings.Contains(pressedButton, "Install certificate for Safari") {
+					cert.GenerateCertificates(certDir)
+					err := cert.InstallCertificate(certDir.Join("ca.cert.cer"))
+					// if something goes wrong during the cert install we remove them, so the user is able to retry
+					if err != nil {
+						log.Errorf("cannot install certificates something went wrong: %s", err)
+						cert.DeleteCertificates(certDir)
+					}
+					err = config.SetInstallCertsIni(s.currentConfigFilePath.String(), "true")
+					if err != nil {
+						log.Errorf("cannot set installCerts value in config.ini: %s", err)
+					}
+				} else if strings.Contains(pressedButton, "Uninstall certificate for Safari") {
+					err := cert.UninstallCertificates()
+					if err != nil {
+						log.Errorf("cannot uninstall certificates something went wrong: %s", err)
+					} else {
+						cert.DeleteCertificates(certDir)
+						err = config.SetInstallCertsIni(s.currentConfigFilePath.String(), "false")
+						if err != nil {
+							log.Errorf("cannot set installCerts value in config.ini: %s", err)
+						}
+					}
+				}
+				s.Restart()
 			case <-mPause.ClickedCh:
 				s.Pause()
 			case <-mQuit.ClickedCh:

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -15,8 +15,14 @@
 
 import re
 import requests
+import pytest
+from sys import platform
 
 
+@pytest.mark.skipif(
+    platform == "darwin",
+    reason="on macOS the user is prompted to install certificates",
+)
 def test_version(base_url, agent):
     
     resp = requests.get(f"{base_url}/info")

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -14,8 +14,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import requests
+import pytest
+from sys import platform
 
 
+@pytest.mark.skipif(
+    platform == "darwin",
+    reason="on macOS the user is prompted to install certificates",
+)
 def test_get_tools(base_url, agent):
     
     resp = requests.get(f"{base_url}/v2/pkgs/tools/installed")

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -17,16 +17,25 @@ import time
 import json
 import base64
 import pytest
+from sys import platform
 
 from common import running_on_ci
 message = []
 
 
+@pytest.mark.skipif(
+    platform == "darwin",
+    reason="on macOS the user is prompted to install certificates",
+)
 def test_ws_connection(socketio):
     print('my sid is', socketio.sid)
     assert socketio.sid is not None
 
 
+@pytest.mark.skipif(
+    platform == "darwin",
+    reason="on macOS the user is prompted to install certificates",
+)
 def test_list(socketio, message):
     socketio.emit('command', 'list')
     time.sleep(.2)

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -149,3 +149,10 @@ func VerifyInput(input string, signature string) error {
 	d := h.Sum(nil)
 	return rsa.VerifyPKCS1v15(rsaKey, crypto.SHA256, d, sign)
 }
+
+// UserPrompt executes an osascript and returns the pressed button
+func UserPrompt(dialog string) string {
+	oscmd := exec.Command("osascript", "-e", dialog)
+	pressedButton, _ := oscmd.Output()
+	return string(pressedButton)
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Infrastructure enhancement

* **What is the new behavior?**
<!-- if this is a feature change -->
Safari users are prompted at startup to install the HTTPS certificate and their preference is saved in the `config` file.
It is now possible to obtain the certificate informations (installed, trusted and expiration date) from the Agent menu before performing any action on the keychain.
If the installed certificate is expiring in less than one month, the Agent will ask the user to update it.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No

* **Other information**:
<!-- Any additional information that could help the review process -->
