### PR TITLE
Check if a signed URL is specified and use it download tools

### DIFF
--- a/tools/download.go
+++ b/tools/download.go
@@ -43,11 +43,9 @@ import (
 // If version is not "latest" and behaviour is "replace", it will download the
 // version again. If instead behaviour is "keep" it will not download the version
 // if it already exists.
-//
-// At the moment the value of behaviour is ignored.
 func (t *Tools) Download(pack, name, version, behaviour string) error {
 
-	tool := pkgs.New(t.index, t.directory.String())
+	tool := pkgs.New(t.index, t.directory.String(), behaviour)
 	_, err := tool.Install(context.Background(), &tools.ToolPayload{Name: name, Version: version, Packager: pack})
 	if err != nil {
 		return err

--- a/tools/download.go
+++ b/tools/download.go
@@ -26,13 +26,6 @@ import (
 	"github.com/arduino/arduino-create-agent/gen/tools"
 	"github.com/arduino/arduino-create-agent/utilities"
 	"github.com/arduino/arduino-create-agent/v2/pkgs"
-	"github.com/blang/semver"
-)
-
-// public vars to allow override in the tests
-var (
-	OS   = runtime.GOOS
-	Arch = runtime.GOARCH
 )
 
 // Download will parse the index at the indexURL for the tool to download.
@@ -85,42 +78,12 @@ func (t *Tools) Download(pack, name, version, behaviour string) error {
 	return nil
 }
 
-func findTool(pack, name, version string, data pkgs.Index) (pkgs.Tool, pkgs.System) {
-	var correctTool pkgs.Tool
-	correctTool.Version = "0.0"
-
-	for _, p := range data.Packages {
-		if p.Name != pack {
-			continue
-		}
-		for _, t := range p.Tools {
-			if version != "latest" {
-				if t.Name == name && t.Version == version {
-					correctTool = t
-				}
-			} else {
-				// Find latest
-				v1, _ := semver.Make(t.Version)
-				v2, _ := semver.Make(correctTool.Version)
-				if t.Name == name && v1.Compare(v2) > 0 {
-					correctTool = t
-				}
-			}
-		}
-	}
-
-	// Find the url based on system
-	correctSystem := correctTool.GetFlavourCompatibleWith(OS, Arch)
-
-	return correctTool, correctSystem
-}
-
 func (t *Tools) installDrivers(location string) error {
 	OkPressed := 6
 	extension := ".bat"
 	// add .\ to force locality
 	preamble := ".\\"
-	if OS != "windows" {
+	if runtime.GOOS != "windows" {
 		extension = ".sh"
 		// add ./ to force locality
 		preamble = "./"
@@ -132,7 +95,7 @@ func (t *Tools) installDrivers(location string) error {
 			os.Chdir(location)
 			t.logger(preamble + "post_install" + extension)
 			oscmd := exec.Command(preamble + "post_install" + extension)
-			if OS != "linux" {
+			if runtime.GOOS != "linux" {
 				// spawning a shell could be the only way to let the user type his password
 				TellCommandNotToSpawnShell(oscmd)
 			}

--- a/tools/download_test.go
+++ b/tools/download_test.go
@@ -42,8 +42,8 @@ func TestDownloadCorrectPlatform(t *testing.T) {
 		{"linux", "arm", "arm-linux-gnueabihf"},
 	}
 	defer func() {
-		OS = runtime.GOOS     // restore `runtime.OS`
-		Arch = runtime.GOARCH // restore `runtime.ARCH`
+		pkgs.OS = runtime.GOOS     // restore `runtime.OS`
+		pkgs.Arch = runtime.GOARCH // restore `runtime.ARCH`
 	}()
 	testIndex := paths.New("testdata", "test_tool_index.json")
 	buf, err := testIndex.ReadFile()
@@ -54,10 +54,11 @@ func TestDownloadCorrectPlatform(t *testing.T) {
 	require.NoError(t, err)
 	for _, tc := range testCases {
 		t.Run(tc.hostOS+tc.hostArch, func(t *testing.T) {
-			OS = tc.hostOS     // override `runtime.OS` for testing purposes
-			Arch = tc.hostArch // override `runtime.ARCH` for testing purposes
+			pkgs.OS = tc.hostOS     // override `runtime.OS` for testing purposes
+			pkgs.Arch = tc.hostArch // override `runtime.ARCH` for testing purposes
 			// Find the tool by name
-			correctTool, correctSystem := findTool("arduino-test", "arduino-fwuploader", "2.2.2", data)
+			correctTool, correctSystem, found := pkgs.FindTool("arduino-test", "arduino-fwuploader", "2.2.2", data)
+			require.True(t, found)
 			require.NotNil(t, correctTool)
 			require.NotNil(t, correctSystem)
 			require.Equal(t, correctTool.Name, "arduino-fwuploader")
@@ -78,8 +79,8 @@ func TestDownloadFallbackPlatform(t *testing.T) {
 		{"windows", "amd64", "i686-mingw32"},
 	}
 	defer func() {
-		OS = runtime.GOOS     // restore `runtime.OS`
-		Arch = runtime.GOARCH // restore `runtime.ARCH`
+		pkgs.OS = runtime.GOOS     // restore `runtime.OS`
+		pkgs.Arch = runtime.GOARCH // restore `runtime.ARCH`
 	}()
 	testIndex := paths.New("testdata", "test_tool_index.json")
 	buf, err := testIndex.ReadFile()
@@ -90,10 +91,11 @@ func TestDownloadFallbackPlatform(t *testing.T) {
 	require.NoError(t, err)
 	for _, tc := range testCases {
 		t.Run(tc.hostOS+tc.hostArch, func(t *testing.T) {
-			OS = tc.hostOS     // override `runtime.OS` for testing purposes
-			Arch = tc.hostArch // override `runtime.ARCH` for testing purposes
+			pkgs.OS = tc.hostOS     // override `runtime.OS` for testing purposes
+			pkgs.Arch = tc.hostArch // override `runtime.ARCH` for testing purposes
 			// Find the tool by name
-			correctTool, correctSystem := findTool("arduino-test", "arduino-fwuploader", "2.2.0", data)
+			correctTool, correctSystem, found := pkgs.FindTool("arduino-test", "arduino-fwuploader", "2.2.0", data)
+			require.True(t, found)
 			require.NotNil(t, correctTool)
 			require.NotNil(t, correctSystem)
 			require.Equal(t, correctTool.Name, "arduino-fwuploader")
@@ -145,7 +147,7 @@ func TestDownload(t *testing.T) {
 				if filePath.IsDir() {
 					require.DirExists(t, filePath.String())
 				} else {
-					if OS == "windows" {
+					if runtime.GOOS == "windows" {
 						require.FileExists(t, filePath.String()+".exe")
 					} else {
 						require.FileExists(t, filePath.String())

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -78,18 +78,6 @@ func (t *Tools) getMapValue(key string) (string, bool) {
 	return value, ok
 }
 
-// writeMap() writes installed map to the json file "installed.json"
-func (t *Tools) writeMap() error {
-	t.mutex.RLock()
-	defer t.mutex.RUnlock()
-	b, err := json.Marshal(t.installed)
-	if err != nil {
-		return err
-	}
-	filePath := t.directory.Join("installed.json")
-	return filePath.WriteFile(b)
-}
-
 // readMap() reads the installed map from json file "installed.json"
 func (t *Tools) readMap() error {
 	t.mutex.Lock()

--- a/v2/http.go
+++ b/v2/http.go
@@ -40,7 +40,7 @@ func Server(directory string, index *index.Resource) http.Handler {
 	logAdapter := LogAdapter{Logger: logger}
 
 	// Mount tools
-	toolsSvc := pkgs.New(index, directory)
+	toolsSvc := pkgs.New(index, directory, "replace")
 	toolsEndpoints := toolssvc.NewEndpoints(toolsSvc)
 	toolsServer := toolssvr.New(toolsEndpoints, mux, CustomRequestDecoder, goahttp.ResponseEncoder, errorHandler(logger), nil)
 	toolssvr.Mount(mux, toolsServer)

--- a/v2/pkgs/tools.go
+++ b/v2/pkgs/tools.go
@@ -246,8 +246,11 @@ func (t *Tools) Remove(ctx context.Context, payload *tools.ToolPayload) (*tools.
 func rename(base string) extract.Renamer {
 	return func(path string) string {
 		parts := strings.Split(filepath.ToSlash(path), "/")
-		path = strings.Join(parts[1:], "/")
-		path = filepath.Join(base, path)
+		newPath := strings.Join(parts[1:], "/")
+		if newPath == "" {
+			newPath = filepath.Join(newPath, path)
+		}
+		path = filepath.Join(base, newPath)
 		return path
 	}
 }

--- a/v2/pkgs/tools_test.go
+++ b/v2/pkgs/tools_test.go
@@ -45,7 +45,7 @@ func TestTools(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp)
+	service := pkgs.New(Index, tmp, "replace")
 
 	ctx := context.Background()
 
@@ -126,7 +126,7 @@ func TestEvilFilename(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp)
+	service := pkgs.New(Index, tmp, "replace")
 
 	ctx := context.Background()
 
@@ -195,7 +195,7 @@ func TestInstalledHead(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp)
+	service := pkgs.New(Index, tmp, "replace")
 
 	ctx := context.Background()
 
@@ -216,7 +216,7 @@ func TestInstall(t *testing.T) {
 		LastRefresh: time.Now(),
 	}
 
-	tool := pkgs.New(testIndex, tmp)
+	tool := pkgs.New(testIndex, tmp, "replace")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Code enhancement

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
There are two ways of dowloading tools: [Download](https://github.com/arduino/arduino-create-agent/blob/b350f563ff253d05199dda8e07718518a6cef30d/tools/download.go#L56-L177) and [Install](https://github.com/arduino/arduino-create-agent/blob/b350f563ff253d05199dda8e07718518a6cef30d/v2/pkgs/tools.go#L146-L234). The first one downloads and installs the tools from the package index only, while it is possible to provide a signed URL and a checksum to the second one to download a tool from there.

* **What is the new behavior?**
<!-- if this is a feature change -->
`Download` is wrapped inside `DownloadFromURL` to align it to `Install`.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No
