### PR TITLE
Create a single universal executable for macOS

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -30,6 +30,7 @@ on:
   repository_dispatch:
 
 env:
+  PROJECT_NAME: arduino-create-agent
   GO_VERSION: "1.21"
 
 jobs:
@@ -119,18 +120,38 @@ jobs:
         run: task go:build-win # GOARCH=amd64 by default on the runners
         if: runner.os == 'Windows' && matrix.arch == '-amd64'
 
-      - name: Build the Agent for macos
+      - name: Build the Agent for macos amd 64
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
           CGO_CFLAGS: -mmacosx-version-min=10.15
           CGO_LDFLAGS: -mmacosx-version-min=10.15
-        run: task go:build
+        run: |
+          task go:build
+          mv ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME}}_amd64
+        if: runner.os == 'macOS'
+
+      - name: Build the Agent for macos amd 64
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.15
+          CGO_LDFLAGS: -mmacosx-version-min=10.15
+          GOARCH: arm64
+          CGO_ENABLED: 1
+        run: |
+          task go:build
+          mv ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME}}_arm64
+        if: runner.os == 'macOS'
+
+      - name: Create universal macos executable
+        run: |
+          lipo -create -output ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME}}_amd64 ${{ env.PROJECT_NAME}}_arm64
+          rm ${{ env.PROJECT_NAME}}_amd64 ${{ env.PROJECT_NAME}}_arm64
         if: runner.os == 'macOS'
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: arduino-create-agent-${{ matrix.os }}${{ matrix.arch }}
+          name: ${{ env.PROJECT_NAME}}-${{ matrix.os }}${{ matrix.arch }}
           path: |
-            arduino-create-agent*
+            ${{ env.PROJECT_NAME}}*
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,13 +107,33 @@ jobs:
         run: task go:build-win # GOARCH=amd64 by default on the runners
         if: matrix.os == 'windows-2019' && matrix.arch == 'amd64'
 
-      - name: Build the Agent for macos
+      - name: Build the Agent for macos amd64
         env:
           CGO_ENABLED: 1
           MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
           CGO_CFLAGS: -mmacosx-version-min=10.15
           CGO_LDFLAGS: -mmacosx-version-min=10.15
-        run: task go:build
+        run: |
+          task go:build
+          mv ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_amd64
+        if: matrix.os == 'macos-12'
+
+      - name: Build the Agent for macos arm64
+        env:
+          CGO_ENABLED: 1
+          MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
+          CGO_CFLAGS: -mmacosx-version-min=10.15
+          CGO_LDFLAGS: -mmacosx-version-min=10.15
+          GOARCH: arm64
+        run: |
+          task go:build
+          mv ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_arm64
+        if: matrix.os == 'macos-12'
+
+      - name: Create universal macos executable
+        run: |
+          lipo -create -output ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_amd64 ${{ env.PROJECT_NAME }}_arm64
+          rm ${{ env.PROJECT_NAME }}_amd64 ${{ env.PROJECT_NAME }}_arm64
         if: matrix.os == 'macos-12'
 
         # this will create `public/` dir with compressed full bin (<version>/<os>-<arch>.gz) and a json file
@@ -121,7 +141,6 @@ jobs:
         run: go-selfupdate ${{ env.PROJECT_NAME }}${{ matrix.ext }} ${TAG_VERSION}
         if: matrix.arch != '386' && steps.prerelease.outputs.IS_PRE != 'true'
 
-        # for now we do not distribute m1 build, this is a workaround for now
       - name: Copy autoupdate file for darwin-arm64 (m1 arch)
         working-directory: public/
         run: |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Get the [latest version](https://github.com/arduino/arduino-create-agent/release
 ## Apple silicon support
 
 The Arduino Agent is supported both on Intel and Apple silicon computers. This includes devices with the M1, M2 and M3 processors.  
-At the moment the Arduino Agent is only built for Intel architectures, but Apple silicon devices can run it thanks to the [Rosetta 2](https://support.apple.com/en-us/HT211861) translation layer by Apple.
+The Arduino Agent is built both for Intel architectures and Apple silicon devices, but distributed as a single universal executable for macOS.
 
 ## Documentation
 
@@ -50,7 +50,7 @@ The documentation has been moved to the [wiki](https://github.com/arduino/arduin
 
 ### Submitting an issue
 
-When submitting a new issue please search for duplicates before creating a new one. Help us by providing  useful context and information. Please attach the output of the commands running at the debug console or attach [crash reports](https://github.com/arduino/arduino-create-agent/wiki/How-to-use-crashreport-functionality) if useful.
+When submitting a new issue please search for duplicates before creating a new one. Help us by providing useful context and information. Please attach the output of the commands running at the debug console or attach [crash reports](https://github.com/arduino/arduino-create-agent/wiki/How-to-use-crashreport-functionality) if useful.
 
 #### Security
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,7 +84,7 @@ tasks:
     cmds:
       - poetry run pytest tests
 
-   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
+    # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
   poetry:install-deps:
     desc: Install dependencies managed by Poetry
     cmds:
@@ -138,7 +138,6 @@ tasks:
       - task: go:vet
       - task: go:lint
 
-      
 vars:
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/release-go-task/Taskfile.yml
   PROJECT_NAME: arduino-create-agent

--- a/updater/updater_darwin.go
+++ b/updater/updater_darwin.go
@@ -143,7 +143,7 @@ func checkForUpdates(currentVersion string, updateURL string, cmdName string) (s
 
 	// Install new app
 	logrus.WithField("from", tmpAppPath).WithField("to", currentAppPath).Info("Copying updated app")
-	if err := tmpAppPath.CopyDirTo(currentAppPath); err != nil {
+	if err := tmpAppPath.CopyDirTo(currentAppPath); err != nil || !paths.New(executablePath).Exist() {
 		// Try rollback changes
 		_ = currentAppPath.RemoveAll()
 		_ = oldAppPath.Rename(currentAppPath)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Instead of relying on the Rosetta translation to distribute the Agent for arm architectures, a single universal executable is created. It runs natively on both Apple silicon and Intel-based Mac computers.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No

* **Other information**:
<!-- Any additional information that could help the review process -->
