### PR TITLE
Improve `installed.json` handling in `v2/tools`

### DIFF
--- a/tools/download.go
+++ b/tools/download.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/arduino/arduino-create-agent/gen/tools"
 	"github.com/arduino/arduino-create-agent/utilities"
-	"github.com/arduino/arduino-create-agent/v2/pkgs"
 )
 
 // Download will parse the index at the indexURL for the tool to download.
@@ -45,8 +44,8 @@ import (
 // if it already exists.
 func (t *Tools) Download(pack, name, version, behaviour string) error {
 
-	tool := pkgs.New(t.index, t.directory.String(), behaviour)
-	_, err := tool.Install(context.Background(), &tools.ToolPayload{Name: name, Version: version, Packager: pack})
+	t.tools.SetBehaviour(behaviour)
+	_, err := t.tools.Install(context.Background(), &tools.ToolPayload{Name: name, Version: version, Packager: pack})
 	if err != nil {
 		return err
 	}

--- a/tools/download_test.go
+++ b/tools/download_test.go
@@ -160,3 +160,23 @@ func TestDownload(t *testing.T) {
 		})
 	}
 }
+
+func TestCorruptedInstalled(t *testing.T) {
+	// prepare the test environment
+	tempDir := t.TempDir()
+	tempDirPath := paths.New(tempDir)
+	testIndex := index.Resource{
+		IndexFile:   *paths.New("testdata", "test_tool_index.json"),
+		LastRefresh: time.Now(),
+	}
+	corruptedJSON := tempDirPath.Join("installed.json")
+	fileJSON, err := corruptedJSON.Create()
+	require.NoError(t, err)
+	defer fileJSON.Close()
+	_, err = fileJSON.Write([]byte("Hello"))
+	require.NoError(t, err)
+	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) })
+	// Download the tool
+	err = testTools.Download("arduino-test", "avrdude", "6.3.0-arduino17", "keep")
+	require.NoError(t, err)
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/arduino/arduino-create-agent/index"
+	"github.com/arduino/arduino-create-agent/v2/pkgs"
 	"github.com/arduino/go-paths-helper"
 	"github.com/xrash/smetrics"
 )
@@ -47,6 +48,7 @@ type Tools struct {
 	logger    func(msg string)
 	installed map[string]string
 	mutex     sync.RWMutex
+	tools     *pkgs.Tools
 }
 
 // New will return a Tool object, allowing the caller to execute operations on it.
@@ -60,6 +62,7 @@ func New(directory *paths.Path, index *index.Resource, logger func(msg string)) 
 		logger:    logger,
 		installed: map[string]string{},
 		mutex:     sync.RWMutex{},
+		tools:     pkgs.New(index, directory.String(), "replace"),
 	}
 	_ = t.readMap()
 	return t

--- a/v2/pkgs/tools.go
+++ b/v2/pkgs/tools.go
@@ -331,6 +331,11 @@ func (t *Tools) writeInstalled(path string) error {
 	return os.WriteFile(installedFile, data, 0644)
 }
 
+// SetBehaviour sets the download behaviour to either keep or replace
+func (t *Tools) SetBehaviour(behaviour string) {
+	t.behaviour = behaviour
+}
+
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
 	if err == nil {

--- a/v2/pkgs/tools.go
+++ b/v2/pkgs/tools.go
@@ -290,8 +290,8 @@ func rename(base string) extract.Renamer {
 }
 
 func (t *Tools) readInstalled() error {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
 	// read installed.json
 	installedFile, err := utilities.SafeJoin(t.folder, "installed.json")
 	if err != nil {
@@ -305,8 +305,8 @@ func (t *Tools) readInstalled() error {
 }
 
 func (t *Tools) writeInstalled(path string) error {
-	t.mutex.RLock()
-	defer t.mutex.RUnlock()
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
 
 	parts := strings.Split(path, string(filepath.Separator))
 	tool := parts[len(parts)-2]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [x] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->
Code enhancement

- **What is the current behavior?**
<!-- You can also link to an open issue here -->
The `installed.json` is read everytime it needs to be updated and there is no mutex policy to prevent file corruption.

* **What is the new behavior?**
<!-- if this is a feature change -->
Information from `installed.json` is stored in a map and a mutex policy is introduced.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->
No

* **Other information**:
<!-- Any additional information that could help the review process -->
