### PR TITLE
upload: don't ignore BindJSON errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -80,9 +80,11 @@ type Upload struct {
 var uploadStatusStr = "ProgrammerStatus"
 
 func uploadHandler(c *gin.Context) {
-
 	data := new(Upload)
-	c.BindJSON(data)
+	if err := c.BindJSON(data); err != nil {
+		c.String(http.StatusBadRequest, fmt.Sprintf("err with the payload. %v", err.Error()))
+		return
+	}
 
 	log.Printf("%+v %+v %+v %+v %+v %+v", data.Port, data.Board, data.Rewrite, data.Commandline, data.Extra, data.Filename)
 

--- a/main_test.go
+++ b/main_test.go
@@ -57,11 +57,6 @@ func TestUploadHandlerAgainstEvilFileNames(t *testing.T) {
 	r.POST("/", uploadHandler)
 	ts := httptest.NewServer(r)
 
-	fmt.Println(base64.StdEncoding.EncodeToString([]byte("test")))
-
-	//Padding: dGVzdA==
-	//Raw: dGVzdA
-
 	uploadEvilFileName := Upload{
 		Port:       "/dev/ttyACM0",
 		Board:      "arduino:avr:uno",


### PR DESCRIPTION
When we send an HTTP request to the `upload` endpoint, we include a JSON payload. This payload is then decoded into the `Upload` struct using the `BindJSON` function from the Gin framework.

However, when we have a `[]byte` field, the expectation is that the corresponding field sent over the wire is base64 encoded with padding. If the value is not properly padded, the function returns an error.

Before this PR, we were silently ignoring this error, leading to odd behavior on the frontend:
- A payload with a `hex` field containing an unpadded base64 string is sent.
- `BindJSON` silently fails and sets the HTTP status to 400.
- Despite this failure, we continue executing the handler.
- Once the handler completes, we return the 400 error, but by that point, the upload process has already started.

This PR fixes the issue by properly checking for `BindJSON` errors and exiting early if any are found.

I'm not sure if the error was ignored intentionally for compatibility reasons, but I don’t think so, since this endpoint is used by the cloud editor, which behaves unpredictably when receiving a 400 error.
