### PR TITLE
ci: fix the `check-errors` by updating `libwebkit2gtk`

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -82,7 +82,7 @@ jobs:
           version: 3.x
 
       - name: Install Dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends build-essential libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev
+        run: sudo apt update && sudo apt install -y --no-install-recommends build-essential libgtk-3-dev libwebkit2gtk-4.1-0 libappindicator3-dev
 
       - name: Check for errors
         env:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
The `check-errors` was failing with this error:
```
Reading state information...
E: Unable to locate package libwebkit2gtk-4.0-dev
E: Couldn't find any package by glob 'libwebkit2gtk-4.0-dev'
```
This may be due to the fact the ubuntu:latest is using ubuntu24.0 starting from 5th Dec 2024. https://github.com/actions/runner-images/issues/10636

Use the `libwebkit2gtk-4.1-0` instead of `libwebkit2gtk-4.0-dev`

- **What is the current behavior?**
<!-- You can also link to an open issue here -->

* **What is the new behavior?**
<!-- if this is a feature change -->

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->

* **Other information**:
<!-- Any additional information that could help the review process -->
