### PR TITLE
fix(ci): change the name of macos build for `arm` platform

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -130,7 +130,7 @@ jobs:
           mv ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME}}_amd64
         if: runner.os == 'macOS'
 
-      - name: Build the Agent for macos amd 64
+      - name: Build the Agent for macos arm 64
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15 # minimum supported version for mac
           CGO_CFLAGS: -mmacosx-version-min=10.15


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
<!-- Bug fix, feature, ... -->

- **What is the current behavior?**
There are two "Build the Agent for macos amd 64" name in the github action.

* **What is the new behavior?**
Rename the second with the `arm`.

- **Does this PR introduce a breaking change?**
<!-- What changes might users need to make in their workflow or application due to this PR? -->

* **Other information**:
<!-- Any additional information that could help the review process -->
