### PR TITLE
Update format of dependency license metadata

### DIFF
--- a/.licenses/arduino-create-agent/go/github.com/arduino/go-serial-utils.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/arduino/go-serial-utils.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/arduino/go-serial-utils
 version: v0.1.2
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/arduino/go-serial-utils
 license: gpl-3.0
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/blang/semver.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/blang/semver.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/blang/semver
 version: v3.5.1+incompatible
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/blang/semver
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/blang/semver.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/blang/semver.dep.yml
@@ -33,3 +33,4 @@ licenses:
 - sources: README.md
   text: See [LICENSE](LICENSE) file.
 notices: []
+...

--- a/.licenses/arduino-create-agent/go/github.com/creack/goselect.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/creack/goselect.dep.yml
@@ -33,3 +33,4 @@ licenses:
 - sources: README.md
   text: Released under the [MIT license](LICENSE).
 notices: []
+...

--- a/.licenses/arduino-create-agent/go/github.com/creack/goselect.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/creack/goselect.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/creack/goselect
 version: v0.1.2
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/creack/goselect
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/gin-contrib/sse.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/gin-contrib/sse.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/gin-contrib/sse
 version: v0.1.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/gin-contrib/sse
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/gin-gonic/gin/binding.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/gin-gonic/gin/binding.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/gin-gonic/gin/binding
 version: v1.10.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/gin-gonic/gin/binding
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/gin-gonic/gin/internal/bytesconv.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/gin-gonic/gin/internal/bytesconv.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/gin-gonic/gin/internal/bytesconv
 version: v1.10.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/gin-gonic/gin/internal/bytesconv
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/gin-gonic/gin/internal/json.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/gin-gonic/gin/internal/json.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/gin-gonic/gin/internal/json
 version: v1.10.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/gin-gonic/gin/internal/json
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/gin-gonic/gin/render.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/gin-gonic/gin/render.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/gin-gonic/gin/render
 version: v1.10.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/gin-gonic/gin/render
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/googollee/go-engine.io
 version: v0.0.0-20180829091931-e2f255711dcb
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/googollee/go-engine.io
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/message.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/message.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/googollee/go-engine.io/message
 version: v0.0.0-20180829091931-e2f255711dcb
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/googollee/go-engine.io/message
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/parser.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/parser.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/googollee/go-engine.io/parser
 version: v0.0.0-20180829091931-e2f255711dcb
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/googollee/go-engine.io/parser
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/polling.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/polling.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/googollee/go-engine.io/polling
 version: v0.0.0-20180829091931-e2f255711dcb
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/googollee/go-engine.io/polling
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/transport.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/transport.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/googollee/go-engine.io/transport
 version: v0.0.0-20180829091931-e2f255711dcb
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/googollee/go-engine.io/transport
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/websocket.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/googollee/go-engine.io/websocket.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/googollee/go-engine.io/websocket
 version: v0.0.0-20180829091931-e2f255711dcb
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/googollee/go-engine.io/websocket
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/h2non/filetype.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/h2non/filetype.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/h2non/filetype
 version: v1.1.3
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/h2non/filetype
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/h2non/filetype/matchers.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/h2non/filetype/matchers.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/h2non/filetype/matchers
 version: v1.1.3
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/h2non/filetype/matchers
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/h2non/filetype/matchers/isobmff.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/h2non/filetype/matchers/isobmff.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/h2non/filetype/matchers/isobmff
 version: v1.1.3
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/h2non/filetype/matchers/isobmff
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/h2non/filetype/types.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/h2non/filetype/types.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/h2non/filetype/types
 version: v1.1.3
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/h2non/filetype/types
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/mattn/go-shellwords.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/mattn/go-shellwords.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/mattn/go-shellwords
 version: v1.0.12
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/mattn/go-shellwords
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/pelletier/go-toml/v2/internal/characters.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/pelletier/go-toml/v2/internal/characters.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/pelletier/go-toml/v2/internal/characters
 version: v2.2.2
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/characters
 license: other
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/pelletier/go-toml/v2/internal/danger.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/pelletier/go-toml/v2/internal/danger.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/pelletier/go-toml/v2/internal/danger
 version: v2.2.2
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/danger
 license: other
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/pelletier/go-toml/v2/internal/tracker.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/pelletier/go-toml/v2/internal/tracker.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/pelletier/go-toml/v2/internal/tracker
 version: v2.2.2
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/pelletier/go-toml/v2/internal/tracker
 license: other
 licenses:

--- a/.licenses/arduino-create-agent/go/github.com/xrash/smetrics.dep.yml
+++ b/.licenses/arduino-create-agent/go/github.com/xrash/smetrics.dep.yml
@@ -2,7 +2,7 @@
 name: github.com/xrash/smetrics
 version: v0.0.0-20170218160415-a3153f7040e9
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/github.com/xrash/smetrics
 license: mit
 licenses:

--- a/.licenses/arduino-create-agent/go/go.bug.st/serial/unixutils.dep.yml
+++ b/.licenses/arduino-create-agent/go/go.bug.st/serial/unixutils.dep.yml
@@ -2,7 +2,7 @@
 name: go.bug.st/serial/unixutils
 version: v1.6.1
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/go.bug.st/serial/unixutils
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-create-agent/go/golang.org/x/text/internal/language.dep.yml
+++ b/.licenses/arduino-create-agent/go/golang.org/x/text/internal/language.dep.yml
@@ -2,7 +2,7 @@
 name: golang.org/x/text/internal/language
 version: v0.15.0
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/golang.org/x/text/internal/language
 license: bsd-3-clause
 licenses:

--- a/.licenses/arduino-create-agent/go/gopkg.in/inconshreveable/go-update.v0/download.dep.yml
+++ b/.licenses/arduino-create-agent/go/gopkg.in/inconshreveable/go-update.v0/download.dep.yml
@@ -2,7 +2,7 @@
 name: gopkg.in/inconshreveable/go-update.v0/download
 version: v0.0.0-20150814200126-d8b0b1d421aa
 type: go
-summary: 
+summary:
 homepage: https://pkg.go.dev/gopkg.in/inconshreveable/go-update.v0/download
 license: apache-2.0
 licenses:


### PR DESCRIPTION
The [**Licensed**](https://github.com/licensee/licensed) tool is used to check for incompatible licenses in the project dependencies. The tool relies on a cache of metadata stored in the repository.

An older version of **Licensed** was in use at the time the cache was established. There are some minor differences in the format of the metadata generated by the version of **Licensed** currently in use.

Even though there is no technical significance to the format differences, they are disruptive in that they result in irrelevant diffs in specific metadata files when they are regenerated after a dependency bump. Rather than dealing with these diffs over time, it will be best to instead update the metadata to the new format comprehensively.