### PR TITLE
fix: allow to specify custom `signatureKey`  in the `config.ini`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,11 @@ jobs:
     environment: production
 
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/conn.go
+++ b/conn.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/rsa"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -79,111 +80,113 @@ type Upload struct {
 
 var uploadStatusStr = "ProgrammerStatus"
 
-func uploadHandler(c *gin.Context) {
-	data := new(Upload)
-	if err := c.BindJSON(data); err != nil {
-		c.String(http.StatusBadRequest, fmt.Sprintf("err with the payload. %v", err.Error()))
-		return
-	}
-
-	log.Printf("%+v %+v %+v %+v %+v %+v", data.Port, data.Board, data.Rewrite, data.Commandline, data.Extra, data.Filename)
-
-	if data.Port == "" {
-		c.String(http.StatusBadRequest, "port is required")
-		return
-	}
-
-	if data.Board == "" {
-		c.String(http.StatusBadRequest, "board is required")
-		log.Error("board is required")
-		return
-	}
-
-	if !data.Extra.Network {
-		if data.Signature == "" {
-			c.String(http.StatusBadRequest, "signature is required")
+func uploadHandler(pubKey *rsa.PublicKey) func(*gin.Context) {
+	return func(c *gin.Context) {
+		data := new(Upload)
+		if err := c.BindJSON(data); err != nil {
+			c.String(http.StatusBadRequest, fmt.Sprintf("err with the payload. %v", err.Error()))
 			return
 		}
 
-		if data.Commandline == "" {
-			c.String(http.StatusBadRequest, "commandline is required for local board")
+		log.Printf("%+v %+v %+v %+v %+v %+v", data.Port, data.Board, data.Rewrite, data.Commandline, data.Extra, data.Filename)
+
+		if data.Port == "" {
+			c.String(http.StatusBadRequest, "port is required")
 			return
 		}
 
-		err := utilities.VerifyInput(data.Commandline, data.Signature)
-
-		if err != nil {
-			c.String(http.StatusBadRequest, "signature is invalid")
+		if data.Board == "" {
+			c.String(http.StatusBadRequest, "board is required")
+			log.Error("board is required")
 			return
 		}
-	}
 
-	buffer := bytes.NewBuffer(data.Hex)
+		if !data.Extra.Network {
+			if data.Signature == "" {
+				c.String(http.StatusBadRequest, "signature is required")
+				return
+			}
 
-	filePath, err := utilities.SaveFileonTempDir(data.Filename, buffer)
-	if err != nil {
-		c.String(http.StatusBadRequest, err.Error())
-		return
-	}
+			if data.Commandline == "" {
+				c.String(http.StatusBadRequest, "commandline is required for local board")
+				return
+			}
 
-	tmpdir, err := os.MkdirTemp("", "extrafiles")
-	if err != nil {
-		c.String(http.StatusBadRequest, err.Error())
-		return
-	}
+			err := utilities.VerifyInput(data.Commandline, data.Signature, pubKey)
 
-	for _, extraFile := range data.ExtraFiles {
-		path, err := utilities.SafeJoin(tmpdir, extraFile.Filename)
-		if err != nil {
-			c.String(http.StatusBadRequest, err.Error())
-			return
+			if err != nil {
+				c.String(http.StatusBadRequest, "signature is invalid")
+				return
+			}
 		}
-		log.Printf("Saving %s on %s", extraFile.Filename, path)
 
-		err = os.MkdirAll(filepath.Dir(path), 0744)
+		buffer := bytes.NewBuffer(data.Hex)
+
+		filePath, err := utilities.SaveFileonTempDir(data.Filename, buffer)
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
 
-		err = os.WriteFile(path, extraFile.Hex, 0644)
+		tmpdir, err := os.MkdirTemp("", "extrafiles")
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
+
+		for _, extraFile := range data.ExtraFiles {
+			path, err := utilities.SafeJoin(tmpdir, extraFile.Filename)
+			if err != nil {
+				c.String(http.StatusBadRequest, err.Error())
+				return
+			}
+			log.Printf("Saving %s on %s", extraFile.Filename, path)
+
+			err = os.MkdirAll(filepath.Dir(path), 0744)
+			if err != nil {
+				c.String(http.StatusBadRequest, err.Error())
+				return
+			}
+
+			err = os.WriteFile(path, extraFile.Hex, 0644)
+			if err != nil {
+				c.String(http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+
+		if data.Rewrite != "" {
+			data.Board = data.Rewrite
+		}
+
+		go func() {
+			// Resolve commandline
+			commandline, err := upload.PartiallyResolve(data.Board, filePath, tmpdir, data.Commandline, data.Extra, Tools)
+			if err != nil {
+				send(map[string]string{uploadStatusStr: "Error", "Msg": err.Error()})
+				return
+			}
+
+			l := PLogger{Verbose: true}
+
+			// Upload
+			if data.Extra.Network {
+				err = errors.New("network upload is not supported anymore, pease use OTA instead")
+			} else {
+				send(map[string]string{uploadStatusStr: "Starting", "Cmd": "Serial"})
+				err = upload.Serial(data.Port, commandline, data.Extra, l)
+			}
+
+			// Handle result
+			if err != nil {
+				send(map[string]string{uploadStatusStr: "Error", "Msg": err.Error()})
+				return
+			}
+			send(map[string]string{uploadStatusStr: "Done", "Flash": "Ok"})
+		}()
+
+		c.String(http.StatusAccepted, "")
 	}
-
-	if data.Rewrite != "" {
-		data.Board = data.Rewrite
-	}
-
-	go func() {
-		// Resolve commandline
-		commandline, err := upload.PartiallyResolve(data.Board, filePath, tmpdir, data.Commandline, data.Extra, Tools)
-		if err != nil {
-			send(map[string]string{uploadStatusStr: "Error", "Msg": err.Error()})
-			return
-		}
-
-		l := PLogger{Verbose: true}
-
-		// Upload
-		if data.Extra.Network {
-			err = errors.New("network upload is not supported anymore, pease use OTA instead")
-		} else {
-			send(map[string]string{uploadStatusStr: "Starting", "Cmd": "Serial"})
-			err = upload.Serial(data.Port, commandline, data.Extra, l)
-		}
-
-		// Handle result
-		if err != nil {
-			send(map[string]string{uploadStatusStr: "Error", "Msg": err.Error()})
-			return
-		}
-		send(map[string]string{uploadStatusStr: "Done", "Flash": "Ok"})
-	}()
-
-	c.String(http.StatusAccepted, "")
 }
 
 // PLogger sends the info from the upload to the websocket

--- a/conn.go
+++ b/conn.go
@@ -115,6 +115,7 @@ func uploadHandler(pubKey *rsa.PublicKey) func(*gin.Context) {
 			err := utilities.VerifyInput(data.Commandline, data.Signature, pubKey)
 
 			if err != nil {
+				log.WithField("err", err).Error("Error verifying the command")
 				c.String(http.StatusBadRequest, "signature is invalid")
 				return
 			}

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -17,6 +17,6 @@ package globals
 
 // DefaultIndexURL is the default index url
 var (
-	// SignatureKey is the public key used to verify commands and url sent by the builder
-	SignatureKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc0yZr1yUSen7qmE3cxF\nIE12rCksDnqR+Hp7o0nGi9123eCSFcJ7CkIRC8F+8JMhgI3zNqn4cUEn47I3RKD1\nZChPUCMiJCvbLbloxfdJrUi7gcSgUXrlKQStOKF5Iz7xv1M4XOP3JtjXLGo3EnJ1\npFgdWTOyoSrA8/w1rck4c/ISXZSinVAggPxmLwVEAAln6Itj6giIZHKvA2fL2o8z\nCeK057Lu8X6u2CG8tRWSQzVoKIQw/PKK6CNXCAy8vo4EkXudRutnEYHEJlPkVgPn\n2qP06GI+I+9zKE37iqj0k1/wFaCVXHXIvn06YrmjQw6I0dDj/60Wvi500FuRVpn9\ntwIDAQAB\n-----END PUBLIC KEY-----"
+	// ArduinoSignaturePubKey is the public key used to verify commands and url sent by the builder
+	ArduinoSignaturePubKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc0yZr1yUSen7qmE3cxF\nIE12rCksDnqR+Hp7o0nGi9123eCSFcJ7CkIRC8F+8JMhgI3zNqn4cUEn47I3RKD1\nZChPUCMiJCvbLbloxfdJrUi7gcSgUXrlKQStOKF5Iz7xv1M4XOP3JtjXLGo3EnJ1\npFgdWTOyoSrA8/w1rck4c/ISXZSinVAggPxmLwVEAAln6Itj6giIZHKvA2fL2o8z\nCeK057Lu8X6u2CG8tRWSQzVoKIQw/PKK6CNXCAy8vo4EkXudRutnEYHEJlPkVgPn\n2qP06GI+I+9zKE37iqj0k1/wFaCVXHXIvn06YrmjQw6I0dDj/60Wvi500FuRVpn9\ntwIDAQAB\n-----END PUBLIC KEY-----"
 )

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -15,8 +15,15 @@
 
 package globals
 
-// DefaultIndexURL is the default index url
 var (
 	// ArduinoSignaturePubKey is the public key used to verify commands and url sent by the builder
-	ArduinoSignaturePubKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc0yZr1yUSen7qmE3cxF\nIE12rCksDnqR+Hp7o0nGi9123eCSFcJ7CkIRC8F+8JMhgI3zNqn4cUEn47I3RKD1\nZChPUCMiJCvbLbloxfdJrUi7gcSgUXrlKQStOKF5Iz7xv1M4XOP3JtjXLGo3EnJ1\npFgdWTOyoSrA8/w1rck4c/ISXZSinVAggPxmLwVEAAln6Itj6giIZHKvA2fL2o8z\nCeK057Lu8X6u2CG8tRWSQzVoKIQw/PKK6CNXCAy8vo4EkXudRutnEYHEJlPkVgPn\n2qP06GI+I+9zKE37iqj0k1/wFaCVXHXIvn06YrmjQw6I0dDj/60Wvi500FuRVpn9\ntwIDAQAB\n-----END PUBLIC KEY-----"
+	ArduinoSignaturePubKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc0yZr1yUSen7qmE3cxF
+IE12rCksDnqR+Hp7o0nGi9123eCSFcJ7CkIRC8F+8JMhgI3zNqn4cUEn47I3RKD1
+ZChPUCMiJCvbLbloxfdJrUi7gcSgUXrlKQStOKF5Iz7xv1M4XOP3JtjXLGo3EnJ1
+pFgdWTOyoSrA8/w1rck4c/ISXZSinVAggPxmLwVEAAln6Itj6giIZHKvA2fL2o8z
+CeK057Lu8X6u2CG8tRWSQzVoKIQw/PKK6CNXCAy8vo4EkXudRutnEYHEJlPkVgPn
+2qP06GI+I+9zKE37iqj0k1/wFaCVXHXIvn06YrmjQw6I0dDj/60Wvi500FuRVpn9
+twIDAQAB
+-----END PUBLIC KEY-----`
 )

--- a/main.go
+++ b/main.go
@@ -278,11 +278,8 @@ func loop() {
 		}
 	}
 
-	if signatureKey == nil {
-		log.Panicf("signature public key cannot be nil")
-	}
-	if len(*signatureKey) == 0 {
-		log.Panicf("signature public key cannot be empty")
+	if signatureKey == nil || len(*signatureKey) == 0 {
+		log.Panicf("signature public key should be set")
 	}
 	signaturePubKey, err := utilities.ParseRsaPublicKey([]byte(*signatureKey))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -285,9 +285,12 @@ func loop() {
 	if len(*signatureKey) == 0 {
 		log.Panicf("signature public key cannot be empty")
 	}
-	signaturePubKey, err := utilities.ParseRsaPublicKey(*signatureKey)
+	fmt.Println("Signature key:", *signatureKey)
+
+	// when a public key is read fro the .ini file, the '\n' are escape with an additional '\', we need to replace them with '\n'
+	signaturePubKey, err := utilities.ParseRsaPublicKey(strings.ReplaceAll(*signatureKey, "\\n", "\n"))
 	if err != nil {
-		log.Panicf("cannot parse signature key: %s", err)
+		log.Panicf("cannot parse signature key '%s'. %s", *signatureKey, err)
 	}
 
 	// Instantiate Index and Tools
@@ -538,6 +541,8 @@ func parseIni(filename string) (args []string, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Println("Sections:", cfg.Sections())
 
 	for _, section := range cfg.Sections() {
 		for key, val := range section.KeysHash() {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"html/template"
 	"io"
 	"os"
@@ -81,7 +82,7 @@ var (
 	logDump           = iniConf.String("log", "off", "off = (default)")
 	origins           = iniConf.String("origins", "", "Allowed origin list for CORS")
 	portsFilterRegexp = iniConf.String("regex", "usb|acm|com", "Regular expression to filter serial port list")
-	signatureKey      = iniConf.String("signatureKey", globals.SignatureKey, "Pem-encoded public key to verify signed commandlines")
+	signatureKey      = iniConf.String("signatureKey", globals.ArduinoSignaturePubKey, "Pem-encoded public key to verify signed commandlines")
 	updateURL         = iniConf.String("updateUrl", "", "")
 	verbose           = iniConf.Bool("v", true, "show debug logging")
 	crashreport       = iniConf.Bool("crashreport", false, "enable crashreport logging")
@@ -278,9 +279,20 @@ func loop() {
 		}
 	}
 
+	if signatureKey == nil {
+		log.Panicf("signature public key cannot be nil")
+	}
+	if len(*signatureKey) == 0 {
+		log.Panicf("signature public key cannot be empty")
+	}
+	signaturePubKey, err := utilities.ParseRsaPublicKey(*signatureKey)
+	if err != nil {
+		log.Panicf("cannot parse signature key: %s", err)
+	}
+
 	// Instantiate Index and Tools
 	Index = index.Init(*indexURL, config.GetDataDir())
-	Tools = tools.New(config.GetDataDir(), Index, logger)
+	Tools = tools.New(config.GetDataDir(), Index, logger, signaturePubKey)
 
 	// see if we are supposed to wait 5 seconds
 	if *isLaunchSelf {
@@ -454,7 +466,7 @@ func loop() {
 	r.LoadHTMLFiles("templates/nofirefox.html")
 
 	r.GET("/", homeHandler)
-	r.POST("/upload", uploadHandler)
+	r.POST("/upload", uploadHandler(signaturePubKey))
 	r.GET("/socket.io/", socketHandler)
 	r.POST("/socket.io/", socketHandler)
 	r.Handle("WS", "/socket.io/", socketHandler)
@@ -464,7 +476,7 @@ func loop() {
 	r.POST("/update", updateHandler)
 
 	// Mount goa handlers
-	goa := v2.Server(config.GetDataDir().String(), Index)
+	goa := v2.Server(config.GetDataDir().String(), Index, signaturePubKey)
 	r.Any("/v2/*path", gin.WrapH(goa))
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -284,8 +284,7 @@ func loop() {
 	if len(*signatureKey) == 0 {
 		log.Panicf("signature public key cannot be empty")
 	}
-	// when a public key is read from the .ini file, the '\n' are escape with an additional '\', we need to replace them with '\n'
-	signaturePubKey, err := utilities.ParseRsaPublicKey(strings.ReplaceAll(*signatureKey, "\\n", "\n"))
+	signaturePubKey, err := utilities.ParseRsaPublicKey([]byte(*signatureKey))
 	if err != nil {
 		log.Panicf("cannot parse signature key '%s'. %s", *signatureKey, err)
 	}

--- a/main.go
+++ b/main.go
@@ -285,9 +285,7 @@ func loop() {
 	if len(*signatureKey) == 0 {
 		log.Panicf("signature public key cannot be empty")
 	}
-	fmt.Println("Signature key:", *signatureKey)
-
-	// when a public key is read fro the .ini file, the '\n' are escape with an additional '\', we need to replace them with '\n'
+	// when a public key is read from the .ini file, the '\n' are escape with an additional '\', we need to replace them with '\n'
 	signaturePubKey, err := utilities.ParseRsaPublicKey(strings.ReplaceAll(*signatureKey, "\\n", "\n"))
 	if err != nil {
 		log.Panicf("cannot parse signature key '%s'. %s", *signatureKey, err)

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"html/template"
 	"io"
 	"os"
@@ -539,8 +538,6 @@ func parseIni(filename string) (args []string, err error) {
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Println("Sections:", cfg.Sections())
 
 	for _, section := range cfg.Sections() {
 		for key, val := range section.KeysHash() {

--- a/main_test.go
+++ b/main_test.go
@@ -30,8 +30,10 @@ import (
 
 	"github.com/arduino/arduino-create-agent/config"
 	"github.com/arduino/arduino-create-agent/gen/tools"
+	"github.com/arduino/arduino-create-agent/globals"
 	"github.com/arduino/arduino-create-agent/index"
 	"github.com/arduino/arduino-create-agent/upload"
+	"github.com/arduino/arduino-create-agent/utilities"
 	v2 "github.com/arduino/arduino-create-agent/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -54,7 +56,7 @@ func TestValidSignatureKey(t *testing.T) {
 
 func TestUploadHandlerAgainstEvilFileNames(t *testing.T) {
 	r := gin.New()
-	r.POST("/", uploadHandler)
+	r.POST("/", uploadHandler(utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey)))
 	ts := httptest.NewServer(r)
 
 	uploadEvilFileName := Upload{
@@ -90,7 +92,7 @@ func TestUploadHandlerAgainstEvilFileNames(t *testing.T) {
 
 func TestUploadHandlerAgainstBase64WithoutPaddingMustFail(t *testing.T) {
 	r := gin.New()
-	r.POST("/", uploadHandler)
+	r.POST("/", uploadHandler(utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey)))
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
@@ -119,7 +121,7 @@ func TestInstallToolV2(t *testing.T) {
 	Index := index.Init(indexURL, config.GetDataDir())
 
 	r := gin.New()
-	goa := v2.Server(config.GetDataDir().String(), Index)
+	goa := v2.Server(config.GetDataDir().String(), Index, utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
 	r.Any("/v2/*path", gin.WrapH(goa))
 	ts := httptest.NewServer(r)
 
@@ -213,7 +215,7 @@ func TestInstalledHead(t *testing.T) {
 	Index := index.Init(indexURL, config.GetDataDir())
 
 	r := gin.New()
-	goa := v2.Server(config.GetDataDir().String(), Index)
+	goa := v2.Server(config.GetDataDir().String(), Index, utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
 	r.Any("/v2/*path", gin.WrapH(goa))
 	ts := httptest.NewServer(r)
 

--- a/main_test.go
+++ b/main_test.go
@@ -56,7 +56,7 @@ func TestValidSignatureKey(t *testing.T) {
 
 func TestUploadHandlerAgainstEvilFileNames(t *testing.T) {
 	r := gin.New()
-	r.POST("/", uploadHandler(utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey)))
+	r.POST("/", uploadHandler(utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey))))
 	ts := httptest.NewServer(r)
 
 	uploadEvilFileName := Upload{
@@ -92,7 +92,7 @@ func TestUploadHandlerAgainstEvilFileNames(t *testing.T) {
 
 func TestUploadHandlerAgainstBase64WithoutPaddingMustFail(t *testing.T) {
 	r := gin.New()
-	r.POST("/", uploadHandler(utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey)))
+	r.POST("/", uploadHandler(utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey))))
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
@@ -121,7 +121,7 @@ func TestInstallToolV2(t *testing.T) {
 	Index := index.Init(indexURL, config.GetDataDir())
 
 	r := gin.New()
-	goa := v2.Server(config.GetDataDir().String(), Index, utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
+	goa := v2.Server(config.GetDataDir().String(), Index, utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey)))
 	r.Any("/v2/*path", gin.WrapH(goa))
 	ts := httptest.NewServer(r)
 
@@ -215,7 +215,7 @@ func TestInstalledHead(t *testing.T) {
 	Index := index.Init(indexURL, config.GetDataDir())
 
 	r := gin.New()
-	goa := v2.Server(config.GetDataDir().String(), Index, utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
+	goa := v2.Server(config.GetDataDir().String(), Index, utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey)))
 	r.Any("/v2/*path", gin.WrapH(goa))
 	ts := httptest.NewServer(r)
 

--- a/tools/download_test.go
+++ b/tools/download_test.go
@@ -21,7 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/arduino/arduino-create-agent/globals"
 	"github.com/arduino/arduino-create-agent/index"
+	"github.com/arduino/arduino-create-agent/utilities"
 	"github.com/arduino/arduino-create-agent/v2/pkgs"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
@@ -128,7 +130,7 @@ func TestDownload(t *testing.T) {
 		IndexFile:   *paths.New("testdata", "test_tool_index.json"),
 		LastRefresh: time.Now(),
 	}
-	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) })
+	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) }, utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
 
 	for _, tc := range testCases {
 		t.Run(tc.name+"-"+tc.version, func(t *testing.T) {
@@ -175,7 +177,7 @@ func TestCorruptedInstalled(t *testing.T) {
 	defer fileJSON.Close()
 	_, err = fileJSON.Write([]byte("Hello"))
 	require.NoError(t, err)
-	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) })
+	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) }, utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
 	// Download the tool
 	err = testTools.Download("arduino-test", "avrdude", "6.3.0-arduino17", "keep")
 	require.NoError(t, err)

--- a/tools/download_test.go
+++ b/tools/download_test.go
@@ -130,7 +130,7 @@ func TestDownload(t *testing.T) {
 		IndexFile:   *paths.New("testdata", "test_tool_index.json"),
 		LastRefresh: time.Now(),
 	}
-	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) }, utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
+	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) }, utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey)))
 
 	for _, tc := range testCases {
 		t.Run(tc.name+"-"+tc.version, func(t *testing.T) {
@@ -177,7 +177,7 @@ func TestCorruptedInstalled(t *testing.T) {
 	defer fileJSON.Close()
 	_, err = fileJSON.Write([]byte("Hello"))
 	require.NoError(t, err)
-	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) }, utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
+	testTools := New(tempDirPath, &testIndex, func(msg string) { t.Log(msg) }, utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey)))
 	// Download the tool
 	err = testTools.Download("arduino-test", "avrdude", "6.3.0-arduino17", "keep")
 	require.NoError(t, err)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -16,6 +16,7 @@
 package tools
 
 import (
+	"crypto/rsa"
 	"encoding/json"
 	"path/filepath"
 	"strings"
@@ -55,14 +56,14 @@ type Tools struct {
 // The New functions accept the directory to use to host the tools,
 // an index (used to download the tools),
 // and a logger to log the operations
-func New(directory *paths.Path, index *index.Resource, logger func(msg string)) *Tools {
+func New(directory *paths.Path, index *index.Resource, logger func(msg string), signPubKey *rsa.PublicKey) *Tools {
 	t := &Tools{
 		directory: directory,
 		index:     index,
 		logger:    logger,
 		installed: map[string]string{},
 		mutex:     sync.RWMutex{},
-		tools:     pkgs.New(index, directory.String(), "replace"),
+		tools:     pkgs.New(index, directory.String(), "replace", signPubKey),
 	}
 	_ = t.readMap()
 	return t

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -152,7 +152,11 @@ func ParseRsaPublicKey(key []byte) (*rsa.PublicKey, error) {
 		return nil, err
 	}
 
-	return parsedKey.(*rsa.PublicKey), nil
+ publicKey, ok := value.(*rsa.PublicKey)
+    if !ok {
+        return nil,fmt.Errorf("not an rsa key")
+    }
+return publicKey, nil
 }
 
 // MustParseRsaPublicKey parses a public key in PEM format and returns the rsa.PublicKey object.

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -155,6 +155,8 @@ func ParseRsaPublicKey(key string) (*rsa.PublicKey, error) {
 	return parsedKey.(*rsa.PublicKey), nil
 }
 
+// MustParseRsaPublicKey parses a public key in PEM format and returns the rsa.PublicKey object.
+// Panics if the key is invalid.
 func MustParseRsaPublicKey(key string) *rsa.PublicKey {
 	parsedKey, err := ParseRsaPublicKey(key)
 	if err != nil {

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -141,8 +141,8 @@ func VerifyInput(input string, signature string, pubKey *rsa.PublicKey) error {
 
 // ParseRsaPublicKey parses a public key in PEM format and returns the rsa.PublicKey object.
 // Returns an error if the key is invalid.
-func ParseRsaPublicKey(key string) (*rsa.PublicKey, error) {
-	block, _ := pem.Decode([]byte(key))
+func ParseRsaPublicKey(key []byte) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode(key)
 	if block == nil {
 		return nil, errors.New("invalid key")
 	}
@@ -157,7 +157,7 @@ func ParseRsaPublicKey(key string) (*rsa.PublicKey, error) {
 
 // MustParseRsaPublicKey parses a public key in PEM format and returns the rsa.PublicKey object.
 // Panics if the key is invalid.
-func MustParseRsaPublicKey(key string) *rsa.PublicKey {
+func MustParseRsaPublicKey(key []byte) *rsa.PublicKey {
 	parsedKey, err := ParseRsaPublicKey(key)
 	if err != nil {
 		panic(err)

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -152,11 +152,11 @@ func ParseRsaPublicKey(key []byte) (*rsa.PublicKey, error) {
 		return nil, err
 	}
 
- publicKey, ok := value.(*rsa.PublicKey)
-    if !ok {
-        return nil,fmt.Errorf("not an rsa key")
-    }
-return publicKey, nil
+	publicKey, ok := parsedKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an rsa key")
+	}
+	return publicKey, nil
 }
 
 // MustParseRsaPublicKey parses a public key in PEM format and returns the rsa.PublicKey object.

--- a/v2/http.go
+++ b/v2/http.go
@@ -17,6 +17,7 @@ package v2
 
 import (
 	"context"
+	"crypto/rsa"
 	"encoding/json"
 	"net/http"
 
@@ -31,7 +32,7 @@ import (
 )
 
 // Server is the actual server
-func Server(directory string, index *index.Resource) http.Handler {
+func Server(directory string, index *index.Resource, pubKey *rsa.PublicKey) http.Handler {
 	mux := goahttp.NewMuxer()
 
 	// Instantiate logger
@@ -40,7 +41,7 @@ func Server(directory string, index *index.Resource) http.Handler {
 	logAdapter := LogAdapter{Logger: logger}
 
 	// Mount tools
-	toolsSvc := pkgs.New(index, directory, "replace")
+	toolsSvc := pkgs.New(index, directory, "replace", pubKey)
 	toolsEndpoints := toolssvc.NewEndpoints(toolsSvc)
 	toolsServer := toolssvr.New(toolsEndpoints, mux, CustomRequestDecoder, goahttp.ResponseEncoder, errorHandler(logger), nil)
 	toolssvr.Mount(mux, toolsServer)

--- a/v2/pkgs/tools.go
+++ b/v2/pkgs/tools.go
@@ -59,11 +59,11 @@ var (
 //
 // It requires an Index Resource to search for tools
 type Tools struct {
-	index     *index.Resource
-	folder    string
-	behaviour string
-	installed map[string]string
-	mutex     sync.RWMutex
+	index                 *index.Resource
+	folder                string
+	behaviour             string
+	installed             map[string]string
+	mutex                 sync.RWMutex
 	verifySignaturePubKey *rsa.PublicKey // public key used to verify the signature of a command sent to the boards
 }
 

--- a/v2/pkgs/tools.go
+++ b/v2/pkgs/tools.go
@@ -65,7 +65,7 @@ type Tools struct {
 	installed map[string]string
 	mutex     sync.RWMutex
 
-	verifySignaturePubKey *rsa.PublicKey // public key used to verify the signature when a tools is installed
+	verifySignaturePubKey *rsa.PublicKey // public key used to verify the signature of a command sent to the boards
 }
 
 // New will return a Tool object, allowing the caller to execute operations on it.
@@ -170,7 +170,7 @@ func (t *Tools) Install(ctx context.Context, payload *tools.ToolPayload) (*tools
 
 	//if URL is defined and is signed we verify the signature and override the name, payload, version parameters
 	if payload.URL != nil && payload.Signature != nil && payload.Checksum != nil {
-		err := utilities.VerifyInput(*payload.URL, *payload.Signature, t.verifySignaturePubKey) // TODO pass the public key
+		err := utilities.VerifyInput(*payload.URL, *payload.Signature, t.verifySignaturePubKey)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/pkgs/tools.go
+++ b/v2/pkgs/tools.go
@@ -64,7 +64,6 @@ type Tools struct {
 	behaviour string
 	installed map[string]string
 	mutex     sync.RWMutex
-
 	verifySignaturePubKey *rsa.PublicKey // public key used to verify the signature of a command sent to the boards
 }
 

--- a/v2/pkgs/tools_test.go
+++ b/v2/pkgs/tools_test.go
@@ -25,7 +25,9 @@ import (
 
 	"github.com/arduino/arduino-create-agent/config"
 	"github.com/arduino/arduino-create-agent/gen/tools"
+	"github.com/arduino/arduino-create-agent/globals"
 	"github.com/arduino/arduino-create-agent/index"
+	"github.com/arduino/arduino-create-agent/utilities"
 	"github.com/arduino/arduino-create-agent/v2/pkgs"
 	"github.com/arduino/go-paths-helper"
 	"github.com/stretchr/testify/require"
@@ -45,7 +47,7 @@ func TestTools(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp, "replace")
+	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
 
 	ctx := context.Background()
 
@@ -126,7 +128,7 @@ func TestEvilFilename(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp, "replace")
+	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
 
 	ctx := context.Background()
 
@@ -195,7 +197,7 @@ func TestInstalledHead(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp, "replace")
+	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
 
 	ctx := context.Background()
 
@@ -216,7 +218,7 @@ func TestInstall(t *testing.T) {
 		LastRefresh: time.Now(),
 	}
 
-	tool := pkgs.New(testIndex, tmp, "replace")
+	tool := pkgs.New(testIndex, tmp, "replace", utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
 
 	ctx := context.Background()
 

--- a/v2/pkgs/tools_test.go
+++ b/v2/pkgs/tools_test.go
@@ -47,7 +47,7 @@ func TestTools(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
+	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey)))
 
 	ctx := context.Background()
 
@@ -128,7 +128,7 @@ func TestEvilFilename(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
+	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey)))
 
 	ctx := context.Background()
 
@@ -197,7 +197,7 @@ func TestInstalledHead(t *testing.T) {
 	// Instantiate Index
 	Index := index.Init(indexURL, config.GetDataDir())
 
-	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
+	service := pkgs.New(Index, tmp, "replace", utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey)))
 
 	ctx := context.Background()
 
@@ -218,7 +218,7 @@ func TestInstall(t *testing.T) {
 		LastRefresh: time.Now(),
 	}
 
-	tool := pkgs.New(testIndex, tmp, "replace", utilities.MustParseRsaPublicKey(globals.ArduinoSignaturePubKey))
+	tool := pkgs.New(testIndex, tmp, "replace", utilities.MustParseRsaPublicKey([]byte(globals.ArduinoSignaturePubKey)))
 
 	ctx := context.Background()
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-create-agent/pulls)
      before creating one)
- [ ] Tests for the changes have been added (for bug fixes / features)

* **What kind of change does this PR introduce?**
Bug fix. Verify the signatures using a custom public key is not working anymore.

- **What is the current behavior?**
The create-agent ignores the `signatureKey` in the `config.ini` and always uses the Arduino public key, so the signature verification fails.


1. Generate pub/keys pairs like [this](https://github.com/arduino/arduino-create-agent/issues/213#issuecomment-2749219869 )
```
### Create a private key
openssl genrsa -out private_24MAR25_B.pem 2048

### Extract the public key from the private key
openssl rsa -pubout -in private_24MAR25_B.pem -out public_24MAR25_B.pem

### Format the public key for the config.ini file -> paste in Arduino Create config.ini file and add a comment for file name
awk 'NR>0 {printf "%s\\n", $0}' public_24MAR25_B.pem
```

2. Add  the `signatureKey` into the `/home/<user>/.config/ArduinoCreateAgent/config.ini`
```
signatureKey='-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtHP52M8dCYDGaC4UaOvU\ncfLqhteGX75EnbXMr6iOg7r7Of+doFV+Ee233Ly/di15CXaju3EpgUka5QSu6z2m\n4sne32aGw6T/eggY636CKcRHFPFjLmXX0CHq+Evg3E4g8W7Yslo2qu1SP3ySZCqe\nVpZHSeehlxFPpQKWXa1YiNF0gWh3cNQ0wneOsJ+ndShSuQ5C2YnSEoeoiEGVFOS0\nevX4GEdadudGBjHQUKjhj+k3Ydaz014aIIC7CUVkQog9B7vpB+znHJH/gCl9DqYO\n4mjPfHG4c5ppNu455hEe75R5q9bPc7TjBA3jpZsdrBY05lX2Q2nAQgSYIHpf78xl\n7wIDAQAB\n-----END PUBLIC KEY-----\n'
```

3. Sign the command `hello` with the private key generated in the step before  with the go code below

```
import (
	"crypto"
	"crypto/rand"
	"crypto/rsa"
	"crypto/sha256"
	"crypto/x509"
	"encoding/hex"
	"encoding/pem"
	"errors"
	"fmt"
)

func main() {
	key := `-----BEGIN PRIVATE KEY-----
MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC0c/nYzx0JgMZo
<YOUR-REST-OF-PRIVATE-KEY>
-----END PRIVATE KEY-----
`
	res, err := sign([]byte("hello"), []byte(key))
	if err != nil {
		panic(err)
	}
	fmt.Println(string(res))
}

func sign(message []byte, key []byte) (string, error) {
	block, _ := pem.Decode(key)
	if block == nil {
		return "", errors.New("While decoding key " + string(key))
	}
	rng := rand.Reader
	private, err := x509.ParsePKCS8PrivateKey(block.Bytes)
	if err != nil {
		return "", errors.New("While parsing key " + err.Error())
	}

	hashed := sha256.Sum256(message)
	signature, err := rsa.SignPKCS1v15(rng, private.(*rsa.PrivateKey), crypto.SHA256, hashed[:])
	if err != nil {
		return "", errors.New("While signing message ")
	}

	return hex.EncodeToString(signature), nil
}
```
4. Launch the agent and create the `test.sh` script:

```
response=$(curl -s -w " status code: %{http_code}" -X POST -H "Content-Type: application/json" -d '{
   "commandline":"hello",
   "port":"/dev/ttyACM1",
   "board":"arduino:avr:leonardo",
   "signature":"ae4f40d5a4f5d57df432ee41e3d2250fe611ce22c9aa6033dd5d764bff6dd8525342bd7ead24e6d6b3fe72a70a2b94e3073148776010fafff52d37d0afaba69f9390efe19ea8231d2e8f29c68bc6fc5b59cc5a48af237fec921799c9b5f98e5c18fb9efde3d6f19f2df2f7626bd6c42c167a60bb8452c08c4e0aa8e49092c27df709a3eed9b4bc2cf1b22c252d8055fce9c0ce13003e6bde41bbf669f85c409b80e4339af4d08706b1a67c1726393b0528ce4585567d4821b6e981c95805618ff6237171b2ff87ae3b9a0130b32730d3571d18eb8ac4113f70aebca6e2dd0562364cde90fbe4e121b5a84917ad30e8a18e0b6d0ca0152d3a995098eb9c0a761f",
   "filename":"test"
}' http://127.0.0.1:8991/upload)

echo "Response: $response"


```

5. Launch the shell script:
```
$ ./test.sh                                                                                                                                                  
Response: signature is invalid status code: 400
```

* **What is the new behavior?**

Add the `signatureKey`  into the `config.ini` with this format (using backtick) 
```
signatureKey = `-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtHP52M8dCYDGaC4UaOvU
cfLqhteGX75EnbXMr6iOg7r7Of+doFV+Ee233Ly/di15CXaju3EpgUka5QSu6z2m
4sne32aGw6T/eggY636CKcRHFPFjLmXX0CHq+Evg3E4g8W7Yslo2qu1SP3ySZCqe
VpZHSeehlxFPpQKWXa1YiNF0gWh3cNQ0wneOsJ+ndShSuQ5C2YnSEoeoiEGVFOS0
evX4GEdadudGBjHQUKjhj+k3Ydaz014aIIC7CUVkQog9B7vpB+znHJH/gCl9DqYO
4mjPfHG4c5ppNu455hEe75R5q9bPc7TjBA3jpZsdrBY05lX2Q2nAQgSYIHpf78xl
7wIDAQAB
-----END PUBLIC KEY-----`
```
If the `test.sh` is launched, the result is

```
Response:  status code: 202
```



- **Does this PR introduce a breaking change?**
It should not.

Notable changes are the following:
- the `/upload` endpoint logs an error if the signature verification fails `log.WithField("err", err).Error("Error verifying the command")` (while before the error was not shown anywhere)
- the `signatureKey` must be specified in the confi.ini  wrapped with backthick ( ` ) 
- add a section to the [wiki page](https://github.com/arduino/arduino-create-agent/wiki/Advanced-usage#how-to-use-a-custom-privatepublic-key)

* **Other information**:
Other correlated issues
- https://github.com/arduino/arduino-create-agent/issues/213
- https://github.com/arduino/arduino-create-agent/issues/259 
- https://github.com/arduino/arduino-create-agent/issues/863
- https://github.com/arduino/arduino-create-agent/issues/149

Forum discussion about this issue: https://forum.arduino.cc/t/signing-command-line-for-arduino-create-agent/1366082/2
